### PR TITLE
Lot 1: initial database schema and seed tooling

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
-﻿# Exemple de configuration backend
-DATABASE_URL=postgres://user:pass@localhost:5432/budget
+# Exemple de configuration backend
+# DATABASE_URL est utilisé par les scripts de migrations et de seed.
+DATABASE_URL=postgres://budget:budget@localhost:5432/budget
 JWT_SECRET=changeme
 APP_CURRENCY=CHF

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,65 @@
+# Backend — Lot 1
+
+Ce dossier contient le socle de données pour le MVP Budget.
+
+## Prérequis
+- [Node.js](https://nodejs.org/) ≥ 18
+- [npm](https://www.npmjs.com/) (installé avec Node.js)
+- [Docker](https://www.docker.com/) (ou toute instance PostgreSQL 14+ disponible)
+
+## Installation
+1. Installer les dépendances JavaScript :
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Copier le fichier d’exemple d’environnement :
+   ```bash
+   cp .env.example .env
+   ```
+3. Adapter `DATABASE_URL` dans `.env` si nécessaire.
+
+## Lancer PostgreSQL en local (Docker)
+La commande suivante démarre une base PostgreSQL prête à l’emploi :
+```bash
+docker run --name budget-db \
+  -e POSTGRES_USER=budget \
+  -e POSTGRES_PASSWORD=budget \
+  -e POSTGRES_DB=budget \
+  -p 5432:5432 \
+  -d postgres:16
+```
+> Astuce : utiliser `docker stop budget-db` pour arrêter et `docker rm budget-db` pour supprimer le conteneur.
+
+## Migrations
+Appliquer les migrations :
+```bash
+npm run migrate
+```
+Ré-initialiser complètement le schéma (⚠️ supprime toutes les données) :
+```bash
+npm run migrate -- --reset
+```
+
+## Seed de données
+Le script lit `backend/seed.json` et injecte les personnes, comptes, catégories, règles et budgets.
+```bash
+npm run seed
+```
+
+Pour partir d’une base vide et ré-appliquer le seed :
+```bash
+npm run db:reset
+```
+
+## Structure des données
+- `migrations/` : scripts SQL versionnés.
+- `scripts/run-migrations.js` : exécuteur de migrations avec suivi (`schema_migrations`).
+- `scripts/seed.js` : import JSON initial.
+- `seed.json` : source de vérité pour les données de paramétrage.
+
+## Nettoyage
+Arrêter et supprimer le conteneur Docker PostgreSQL :
+```bash
+docker stop budget-db && docker rm budget-db
+```

--- a/backend/migrations/0001_init.sql
+++ b/backend/migrations/0001_init.sql
@@ -1,0 +1,180 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE person (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE account (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    iban TEXT,
+    opening_balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+    currency_code CHAR(3) NOT NULL DEFAULT 'CHF',
+    owner_person_id TEXT REFERENCES person(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (iban)
+);
+
+CREATE TABLE category (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('income','expense','transfer')),
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (kind, name)
+);
+
+CREATE TABLE project (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    target_amount NUMERIC(14,2),
+    budget_amount NUMERIC(14,2),
+    start_date DATE,
+    end_date DATE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE provision (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    target_amount NUMERIC(14,2),
+    category_id INTEGER REFERENCES category(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE import_batch (
+    id BIGSERIAL PRIMARY KEY,
+    source TEXT,
+    original_filename TEXT,
+    hash TEXT NOT NULL UNIQUE,
+    imported_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    rows_count INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'completed',
+    message TEXT
+);
+
+CREATE TABLE rule (
+    id TEXT PRIMARY KEY,
+    target_kind TEXT NOT NULL CHECK (target_kind IN ('income','expense')),
+    category_id INTEGER NOT NULL REFERENCES category(id) ON DELETE RESTRICT,
+    keywords TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    priority INTEGER NOT NULL DEFAULT 0,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE transaction (
+    id BIGSERIAL PRIMARY KEY,
+    account_id TEXT NOT NULL REFERENCES account(id) ON DELETE CASCADE,
+    import_batch_id BIGINT REFERENCES import_batch(id) ON DELETE SET NULL,
+    rule_id TEXT REFERENCES rule(id) ON DELETE SET NULL,
+    project_id TEXT REFERENCES project(id) ON DELETE SET NULL,
+    category_id INTEGER REFERENCES category(id) ON DELETE SET NULL,
+    external_id TEXT,
+    occurred_on DATE NOT NULL,
+    value_date DATE,
+    amount NUMERIC(14,2) NOT NULL,
+    currency_code CHAR(3) NOT NULL DEFAULT 'CHF',
+    description TEXT NOT NULL,
+    raw_description TEXT,
+    balance_after NUMERIC(14,2),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (account_id, external_id)
+);
+
+CREATE TABLE provision_ledger (
+    id BIGSERIAL PRIMARY KEY,
+    provision_id TEXT NOT NULL REFERENCES provision(id) ON DELETE CASCADE,
+    transaction_id BIGINT REFERENCES transaction(id) ON DELETE SET NULL,
+    entry_kind TEXT NOT NULL CHECK (entry_kind IN ('fund','consume','adjust')),
+    amount NUMERIC(14,2) NOT NULL,
+    occurred_on DATE NOT NULL,
+    note TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE budget_monthly (
+    id BIGSERIAL PRIMARY KEY,
+    scope TEXT NOT NULL,
+    category_id INTEGER NOT NULL REFERENCES category(id) ON DELETE CASCADE,
+    period_month DATE NOT NULL,
+    ceiling_amount NUMERIC(14,2) NOT NULL,
+    currency_code CHAR(3) NOT NULL DEFAULT 'CHF',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (scope, category_id, period_month)
+);
+
+CREATE TABLE budget_annual (
+    id BIGSERIAL PRIMARY KEY,
+    scope TEXT NOT NULL,
+    category_id INTEGER NOT NULL REFERENCES category(id) ON DELETE CASCADE,
+    year INTEGER NOT NULL,
+    ceiling_amount NUMERIC(14,2) NOT NULL,
+    currency_code CHAR(3) NOT NULL DEFAULT 'CHF',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (scope, category_id, year)
+);
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_timestamp_person
+BEFORE UPDATE ON person
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_timestamp_account
+BEFORE UPDATE ON account
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_timestamp_category
+BEFORE UPDATE ON category
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_timestamp_project
+BEFORE UPDATE ON project
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_timestamp_provision
+BEFORE UPDATE ON provision
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_timestamp_rule
+BEFORE UPDATE ON rule
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_timestamp_transaction
+BEFORE UPDATE ON transaction
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_timestamp_provision_ledger
+BEFORE UPDATE ON provision_ledger
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_timestamp_budget_monthly
+BEFORE UPDATE ON budget_monthly
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_timestamp_budget_annual
+BEFORE UPDATE ON budget_annual
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "budget-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "migrate": "node ./scripts/run-migrations.js",
+    "seed": "node ./scripts/seed.js",
+    "db:reset": "node ./scripts/run-migrations.js --reset && node ./scripts/seed.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "pg": "^8.11.5"
+  }
+}

--- a/backend/scripts/run-migrations.js
+++ b/backend/scripts/run-migrations.js
@@ -1,0 +1,92 @@
+import { config } from 'dotenv';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client } from 'pg';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+config({ path: path.join(__dirname, '..', '.env') });
+config();
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error('DATABASE_URL is not defined. Please configure backend/.env (see backend/.env.example).');
+  process.exit(1);
+}
+
+const reset = process.argv.includes('--reset');
+const migrationsDir = path.join(__dirname, '..', 'migrations');
+
+async function ensureMigrationsTable(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      name TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+}
+
+async function appliedMigrations(client) {
+  const { rows } = await client.query('SELECT name FROM schema_migrations');
+  return new Set(rows.map((row) => row.name));
+}
+
+async function applyMigration(client, filePath, name) {
+  const sql = await fs.readFile(filePath, 'utf8');
+  console.log(`→ Applying migration ${name}`);
+  await client.query('BEGIN');
+  try {
+    await client.query(sql);
+    await client.query('INSERT INTO schema_migrations (name) VALUES ($1)', [name]);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error(`⚠️  Failed to apply migration ${name}`);
+    throw error;
+  }
+}
+
+async function main() {
+  const client = new Client({ connectionString: databaseUrl });
+
+  try {
+    await client.connect();
+
+    if (reset) {
+      console.log('Resetting public schema…');
+      await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+      await client.query('CREATE SCHEMA IF NOT EXISTS public');
+      await client.query('GRANT USAGE ON SCHEMA public TO public');
+      await client.query('GRANT CREATE ON SCHEMA public TO public');
+    }
+
+    await ensureMigrationsTable(client);
+
+    const files = (await fs.readdir(migrationsDir))
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+
+    const alreadyApplied = await appliedMigrations(client);
+
+    for (const file of files) {
+      if (alreadyApplied.has(file)) {
+        console.log(`✓ Skipping already applied migration ${file}`);
+        continue;
+      }
+
+      const filePath = path.join(migrationsDir, file);
+      await applyMigration(client, filePath, file);
+    }
+
+    console.log('All migrations applied.');
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -1,0 +1,212 @@
+import { config } from 'dotenv';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client } from 'pg';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+config({ path: path.join(__dirname, '..', '.env') });
+config();
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error('DATABASE_URL is not defined. Please configure backend/.env (see backend/.env.example).');
+  process.exit(1);
+}
+
+const seedPath = path.join(__dirname, '..', 'seed.json');
+
+async function loadSeed() {
+  const raw = await fs.readFile(seedPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function upsertPersons(client, persons = []) {
+  for (const person of persons) {
+    await client.query(
+      `INSERT INTO person (id, name, email)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (id)
+       DO UPDATE SET name = EXCLUDED.name, email = EXCLUDED.email, updated_at = NOW()`,
+      [person.id, person.name, person.email ?? null]
+    );
+  }
+}
+
+async function upsertAccounts(client, accounts = [], defaultCurrency) {
+  for (const account of accounts) {
+    await client.query(
+      `INSERT INTO account (id, name, iban, opening_balance, currency_code, owner_person_id)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (id)
+       DO UPDATE SET
+         name = EXCLUDED.name,
+         iban = EXCLUDED.iban,
+         opening_balance = EXCLUDED.opening_balance,
+         currency_code = EXCLUDED.currency_code,
+         owner_person_id = EXCLUDED.owner_person_id,
+         updated_at = NOW()`,
+      [
+        account.id,
+        account.name,
+        account.iban ?? null,
+        account.opening_balance ?? 0,
+        account.currency_code ?? defaultCurrency,
+        account.owner_person_id ?? null
+      ]
+    );
+  }
+}
+
+async function upsertCategories(client, categories = {}) {
+  const kinds = Object.entries(categories);
+  for (const [kind, names] of kinds) {
+    for (const name of names) {
+      await client.query(
+        `INSERT INTO category (name, kind)
+         VALUES ($1, $2)
+         ON CONFLICT (kind, name)
+         DO UPDATE SET updated_at = NOW()`,
+        [name, kind]
+      );
+    }
+  }
+}
+
+async function fetchCategories(client) {
+  const { rows } = await client.query('SELECT id, name, kind FROM category');
+  const map = new Map();
+  for (const row of rows) {
+    map.set(`${row.kind}:${row.name}`, row.id);
+  }
+  return map;
+}
+
+async function upsertRules(client, rules = [], categoryMap) {
+  for (const rule of rules) {
+    const categoryId = categoryMap.get(`${rule.target_kind}:${rule.category}`);
+    if (!categoryId) {
+      throw new Error(`Category ${rule.category} (${rule.target_kind}) not found for rule ${rule.id}`);
+    }
+
+    await client.query(
+      `INSERT INTO rule (id, target_kind, category_id, keywords, priority, enabled)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (id)
+       DO UPDATE SET
+         target_kind = EXCLUDED.target_kind,
+         category_id = EXCLUDED.category_id,
+         keywords = EXCLUDED.keywords,
+         priority = EXCLUDED.priority,
+         enabled = EXCLUDED.enabled,
+         updated_at = NOW()`,
+      [
+        rule.id,
+        rule.target_kind,
+        categoryId,
+        rule.keywords ?? [],
+        rule.priority ?? 0,
+        rule.enabled ?? true
+      ]
+    );
+  }
+}
+
+function parseMonth(period) {
+  if (!/^[0-9]{4}-[0-9]{2}$/.test(period)) {
+    throw new Error(`Invalid monthly budget period: ${period}`);
+  }
+  return `${period}-01`;
+}
+
+async function upsertMonthlyBudgets(client, budgets = [], categoryMap, defaultCurrency) {
+  for (const budget of budgets) {
+    const categoryId = categoryMap.get(`expense:${budget.category}`) ?? categoryMap.get(`income:${budget.category}`);
+    if (!categoryId) {
+      throw new Error(`Category ${budget.category} not found for monthly budget`);
+    }
+    await client.query(
+      `INSERT INTO budget_monthly (scope, category_id, period_month, ceiling_amount, currency_code)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (scope, category_id, period_month)
+       DO UPDATE SET
+         ceiling_amount = EXCLUDED.ceiling_amount,
+         currency_code = EXCLUDED.currency_code,
+         updated_at = NOW()`,
+      [
+        budget.scope,
+        categoryId,
+        parseMonth(budget.period),
+        budget.ceiling_amount,
+        budget.currency_code ?? defaultCurrency
+      ]
+    );
+  }
+}
+
+async function upsertAnnualBudgets(client, budgets = [], categoryMap, defaultCurrency) {
+  for (const budget of budgets) {
+    const categoryId = categoryMap.get(`expense:${budget.category}`) ?? categoryMap.get(`income:${budget.category}`);
+    if (!categoryId) {
+      throw new Error(`Category ${budget.category} not found for annual budget`);
+    }
+    await client.query(
+      `INSERT INTO budget_annual (scope, category_id, year, ceiling_amount, currency_code)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (scope, category_id, year)
+       DO UPDATE SET
+         ceiling_amount = EXCLUDED.ceiling_amount,
+         currency_code = EXCLUDED.currency_code,
+         updated_at = NOW()`,
+      [
+        budget.scope,
+        categoryId,
+        budget.year,
+        budget.ceiling_amount,
+        budget.currency_code ?? defaultCurrency
+      ]
+    );
+  }
+}
+
+async function seed() {
+  const seedData = await loadSeed();
+  const defaultCurrency = seedData.currency ?? 'CHF';
+
+  const client = new Client({ connectionString: databaseUrl });
+
+  await client.connect();
+  await client.query('BEGIN');
+  try {
+    await upsertPersons(client, seedData.persons);
+    await upsertAccounts(client, seedData.accounts, defaultCurrency);
+    await upsertCategories(client, seedData.categories);
+
+    const categoryMap = await fetchCategories(client);
+
+    await upsertRules(client, seedData.rules, categoryMap);
+
+    if (seedData.budgets?.monthly) {
+      await upsertMonthlyBudgets(client, seedData.budgets.monthly, categoryMap, defaultCurrency);
+    }
+
+    if (seedData.budgets?.annual) {
+      await upsertAnnualBudgets(client, seedData.budgets.annual, categoryMap, defaultCurrency);
+    }
+
+    await client.query('COMMIT');
+    console.log('Seed data applied successfully.');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+seed().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add the first SQL migration that creates the MVP schema (people, accounts, budgets, provisions, projects, imports and rules)
- add Node.js helpers to run migrations and seed the database from backend/seed.json
- document backend installation, environment configuration and local PostgreSQL setup

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc206bf748324aaa4a2e083f547df