### PR TITLE
feat: add lot 2 Express API server

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -1,0 +1,159 @@
+# Budget API — Lot 2
+
+Cette API REST (Node.js/Express + PostgreSQL) couvre les besoins du MVP Budget décrits dans la Spec v1. Elle consomme la base de données créée dans le lot 1.
+
+## Pré-requis
+- PostgreSQL initialisé (voir `README.md`).
+- Fichier `backend/.env` renseigné avec `DATABASE_URL`.
+- Dépendances installées : `npm install` dans `backend/`.
+
+## Démarrage local
+```bash
+npm run dev
+```
+Par défaut l'API écoute sur `http://localhost:3000` (variable `PORT` modifiable).
+
+## Authentification
+Aucune authentification n'est encore mise en place pour le MVP.
+
+---
+
+## Personnes (`/persons`)
+| Méthode | Endpoint | Description |
+|---------|----------|-------------|
+| GET | `/persons` | Liste des personnes |
+| POST | `/persons` | Création |
+| GET | `/persons/:id` | Détail |
+| PUT | `/persons/:id` | Mise à jour complète/partielle |
+| DELETE | `/persons/:id` | Suppression |
+
+### Exemple `curl`
+```bash
+curl -X POST http://localhost:3000/persons \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Nouvelle personne","email":"person@example.org"}'
+```
+
+---
+
+## Comptes (`/accounts`)
+Champs : `name`, `iban?`, `opening_balance`, `currency_code`, `owner_person_id?`.
+
+```bash
+curl http://localhost:3000/accounts
+```
+
+---
+
+## Catégories (`/categories`)
+- Paramètre `kind` optionnel pour filtrer (`income`, `expense`, `transfer`).
+
+```bash
+curl http://localhost:3000/categories?kind=expense
+```
+
+---
+
+## Règles (`/rules`)
+Champs : `target_kind`, `category_id`, `keywords[]`, `priority`, `enabled`.
+
+Réordonnancement :
+```bash
+curl -X POST http://localhost:3000/rules/reorder \
+  -H "Content-Type: application/json" \
+  -d '{"items":[{"id":"r1","priority":200},{"id":"r2","priority":150}]}'
+```
+
+---
+
+## Transactions (`/transactions`)
+Champs requis : `account_id`, `occurred_on`, `amount`, `description`.
+Paramètres de liste : `account_id`, `category_id`, `limit`, `offset`.
+
+```bash
+curl -X POST http://localhost:3000/transactions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account_id": "a1",
+    "occurred_on": "2025-01-05",
+    "amount": -85.4,
+    "description": "Courses Migros",
+    "category_id": 2
+  }'
+```
+
+---
+
+## Provisions (`/provisions`)
+Champs : `name`, `description?`, `target_amount?`, `category_id?`.
+Sous-ressource `/provisions/:id/ledger`.
+
+Actions disponibles :
+- `POST /provisions/:id/fund`
+- `POST /provisions/:id/consume`
+- `POST /provisions/:id/transfer`
+- `POST /provisions/:id/cancel`
+
+```bash
+curl -X POST http://localhost:3000/provisions/prov-1/fund \
+  -H "Content-Type: application/json" \
+  -d '{"amount":200,"occurred_on":"2025-02-01"}'
+```
+
+---
+
+## Projets (`/projects`)
+Champs : `name`, `description?`, `target_amount?`, `budget_amount?`, `start_date?`, `end_date?`.
+
+```bash
+curl http://localhost:3000/projects
+```
+
+---
+
+## Budgets (`/budgets`)
+Deux sous-ressources :
+- `/budgets/monthly`
+- `/budgets/annual`
+
+Créer un budget mensuel :
+```bash
+curl -X POST http://localhost:3000/budgets/monthly \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scope": "household",
+    "category_id": 1,
+    "period": "2025-10",
+    "ceiling_amount": 600
+  }'
+```
+
+Créer un budget annuel :
+```bash
+curl -X POST http://localhost:3000/budgets/annual \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scope": "household",
+    "category_id": 2,
+    "year": 2025,
+    "ceiling_amount": 1200
+  }'
+```
+
+---
+
+## Collection Postman
+Un export JSON prêt à l'emploi est disponible dans `docs/postman/Budget-API.postman_collection.json`. Importez-le dans Postman et mettez à jour la variable `baseUrl` si nécessaire.
+
+---
+
+## Gestion des erreurs
+- 400 : validation invalide (type, champ manquant, contrainte de base de données).
+- 404 : ressource introuvable.
+- 409 : duplication (contrainte d'unicité).
+- 500 : erreur interne.
+
+Chaque réponse d'erreur renvoie `{ "error": "message" }` et parfois `details` pour plus de précision.
+
+## Santé
+`GET /health` renvoie `{ "status": "ok" }`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -63,3 +63,13 @@ Arrêter et supprimer le conteneur Docker PostgreSQL :
 ```bash
 docker stop budget-db && docker rm budget-db
 ```
+
+## API HTTP (Lot 2)
+
+Lancer l'API REST (Express) en local :
+
+```bash
+npm run dev
+```
+
+La documentation des endpoints, avec des exemples `curl` et Postman, est disponible dans [`API.md`](./API.md).

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,10 +6,15 @@
   "scripts": {
     "migrate": "node ./scripts/run-migrations.js",
     "seed": "node ./scripts/seed.js",
-    "db:reset": "node ./scripts/run-migrations.js --reset && node ./scripts/seed.js"
+    "db:reset": "node ./scripts/run-migrations.js --reset && node ./scripts/seed.js",
+    "dev": "node --watch ./src/server.js"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "pg": "^8.11.5"
+    "express": "^4.19.2",
+    "morgan": "^1.10.0",
+    "pg": "^8.11.5",
+    "zod": "^3.23.8"
   }
 }

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,57 @@
+import express from 'express';
+import cors from 'cors';
+import morgan from 'morgan';
+
+import personsRouter from './routes/persons.js';
+import accountsRouter from './routes/accounts.js';
+import categoriesRouter from './routes/categories.js';
+import rulesRouter from './routes/rules.js';
+import transactionsRouter from './routes/transactions.js';
+import provisionsRouter from './routes/provisions.js';
+import projectsRouter from './routes/projects.js';
+import budgetsRouter from './routes/budgets.js';
+import { HttpError } from './errors.js';
+
+export function createApp() {
+  const app = express();
+
+  app.use(cors());
+  app.use(express.json());
+  app.use(morgan('dev'));
+
+  app.get('/health', (req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.use('/persons', personsRouter);
+  app.use('/accounts', accountsRouter);
+  app.use('/categories', categoriesRouter);
+  app.use('/rules', rulesRouter);
+  app.use('/transactions', transactionsRouter);
+  app.use('/provisions', provisionsRouter);
+  app.use('/projects', projectsRouter);
+  app.use('/budgets', budgetsRouter);
+
+  app.use((req, res, next) => {
+    next(new HttpError(404, 'Not found'));
+  });
+
+  app.use((err, req, res, next) => {
+    const status = err.status || 500;
+    const payload = {
+      error: err.message || 'Internal server error',
+    };
+
+    if (err.details) {
+      payload.details = err.details;
+    }
+
+    if (status >= 500) {
+      console.error(err);
+    }
+
+    res.status(status).json(payload);
+  });
+
+  return app;
+}

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,0 +1,37 @@
+import { config } from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Pool } from 'pg';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+config({ path: path.join(__dirname, '..', '.env') });
+config();
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error('DATABASE_URL is not defined. Please configure backend/.env.');
+}
+
+export const pool = new Pool({ connectionString });
+
+pool.on('error', (error) => {
+  console.error('Unexpected database error', error);
+});
+
+export async function withTransaction(callback) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await callback(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/backend/src/errors.js
+++ b/backend/src/errors.js
@@ -1,0 +1,41 @@
+export class HttpError extends Error {
+  constructor(status, message, details) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+    if (details) {
+      this.details = details;
+    }
+  }
+}
+
+export function notFound(message = 'Resource not found') {
+  return new HttpError(404, message);
+}
+
+export function badRequest(message = 'Invalid request', details) {
+  return new HttpError(400, message, details);
+}
+
+export function conflict(message = 'Conflict') {
+  return new HttpError(409, message);
+}
+
+export function mapDatabaseError(error) {
+  if (!error || !error.code) {
+    return error;
+  }
+
+  switch (error.code) {
+    case '23505':
+      return conflict('Duplicate value violates unique constraint');
+    case '23503':
+      return badRequest('Invalid reference. Check related entity IDs.');
+    case '23502':
+      return badRequest('Missing required database field.');
+    case '22P02':
+      return badRequest('Invalid input syntax for one of the fields.');
+    default:
+      return error;
+  }
+}

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -1,0 +1,136 @@
+import { Router } from 'express';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { pool } from '../db.js';
+import { HttpError, mapDatabaseError, notFound } from '../errors.js';
+
+const router = Router();
+
+const currencyRegex = /^[A-Z]{3}$/;
+
+const baseSchema = z.object({
+  name: z.string().trim().min(1),
+  iban: z
+    .string()
+    .trim()
+    .min(5)
+    .optional()
+    .nullable(),
+  opening_balance: z.number().finite().default(0),
+  currency_code: z
+    .string()
+    .trim()
+    .regex(currencyRegex, 'Currency must be a 3-letter ISO code')
+    .default('CHF'),
+  owner_person_id: z.string().trim().min(1).nullable().optional(),
+});
+
+const createSchema = baseSchema.extend({
+  id: z.string().trim().min(1).optional(),
+});
+
+const updateSchema = baseSchema.partial().refine((value) => Object.keys(value).length > 0, {
+  message: 'At least one field must be provided',
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM account ORDER BY created_at ASC');
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = createSchema.parse(req.body);
+    const id = payload.id ?? randomUUID();
+    const values = [
+      id,
+      payload.name,
+      payload.iban ?? null,
+      payload.opening_balance,
+      payload.currency_code ?? 'CHF',
+      payload.owner_person_id ?? null,
+    ];
+    const { rows } = await pool.query(
+      `INSERT INTO account (id, name, iban, opening_balance, currency_code, owner_person_id)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      values,
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM account WHERE id = $1', [req.params.id]);
+    if (!rows.length) {
+      throw notFound('Account not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = updateSchema.parse(req.body);
+    const entries = [];
+    const values = [];
+
+    if (payload.name !== undefined) {
+      entries.push('name');
+      values.push(payload.name);
+    }
+    if (payload.iban !== undefined) {
+      entries.push('iban');
+      values.push(payload.iban ?? null);
+    }
+    if (payload.opening_balance !== undefined) {
+      entries.push('opening_balance');
+      values.push(payload.opening_balance);
+    }
+    if (payload.currency_code !== undefined) {
+      entries.push('currency_code');
+      values.push(payload.currency_code);
+    }
+    if (payload.owner_person_id !== undefined) {
+      entries.push('owner_person_id');
+      values.push(payload.owner_person_id ?? null);
+    }
+
+    if (!entries.length) {
+      throw new HttpError(400, 'No fields to update');
+    }
+
+    const setClause = entries.map((field, index) => `${field} = $${index + 2}`).join(', ');
+    const query = `UPDATE account SET ${setClause} WHERE id = $1 RETURNING *`;
+    const { rows } = await pool.query(query, [req.params.id, ...values]);
+    if (!rows.length) {
+      throw notFound('Account not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM account WHERE id = $1', [req.params.id]);
+    if (!rowCount) {
+      throw notFound('Account not found');
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+export default router;

--- a/backend/src/routes/budgets.js
+++ b/backend/src/routes/budgets.js
@@ -1,0 +1,293 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { pool } from '../db.js';
+import { HttpError, mapDatabaseError, notFound } from '../errors.js';
+
+const router = Router();
+
+const currencyRegex = /^[A-Z]{3}$/;
+const monthPattern = /^\d{4}-\d{2}$/;
+
+const baseMonthly = z.object({
+  scope: z.string().trim().min(1),
+  category_id: z.number().int().positive(),
+  period: z
+    .string()
+    .trim()
+    .regex(monthPattern, 'Period must be formatted YYYY-MM'),
+  ceiling_amount: z.number().finite(),
+  currency_code: z
+    .string()
+    .trim()
+    .regex(currencyRegex, 'Currency must be a 3-letter ISO code')
+    .default('CHF'),
+});
+
+const monthlyCreateSchema = baseMonthly;
+const monthlyUpdateSchema = baseMonthly.partial().refine((value) => Object.keys(value).length > 0, {
+  message: 'At least one field must be provided',
+});
+
+const baseAnnual = z.object({
+  scope: z.string().trim().min(1),
+  category_id: z.number().int().positive(),
+  year: z.number().int(),
+  ceiling_amount: z.number().finite(),
+  currency_code: z
+    .string()
+    .trim()
+    .regex(currencyRegex, 'Currency must be a 3-letter ISO code')
+    .default('CHF'),
+});
+
+const annualCreateSchema = baseAnnual;
+const annualUpdateSchema = baseAnnual.partial().refine((value) => Object.keys(value).length > 0, {
+  message: 'At least one field must be provided',
+});
+
+function toMonthDate(period) {
+  return `${period}-01`;
+}
+
+router.get('/monthly', async (req, res, next) => {
+  try {
+    const clauses = [];
+    const values = [];
+
+    if (req.query.scope) {
+      values.push(req.query.scope);
+      clauses.push(`scope = $${values.length}`);
+    }
+    if (req.query.category_id) {
+      const categoryId = Number(req.query.category_id);
+      if (!Number.isInteger(categoryId)) {
+        throw new HttpError(400, 'category_id must be an integer');
+      }
+      values.push(categoryId);
+      clauses.push(`category_id = $${values.length}`);
+    }
+    if (req.query.period) {
+      if (!monthPattern.test(String(req.query.period))) {
+        throw new HttpError(400, 'period must follow YYYY-MM');
+      }
+      values.push(toMonthDate(req.query.period));
+      clauses.push(`period_month = $${values.length}`);
+    }
+
+    let query = 'SELECT * FROM budget_monthly';
+    if (clauses.length) {
+      query += ` WHERE ${clauses.join(' AND ')}`;
+    }
+    query += ' ORDER BY period_month DESC, id DESC';
+
+    const { rows } = await pool.query(query, values);
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/monthly', async (req, res, next) => {
+  try {
+    const payload = monthlyCreateSchema.parse(req.body);
+    const { rows } = await pool.query(
+      `INSERT INTO budget_monthly (scope, category_id, period_month, ceiling_amount, currency_code)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [payload.scope, payload.category_id, toMonthDate(payload.period), payload.ceiling_amount, payload.currency_code ?? 'CHF'],
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/monthly/:id', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM budget_monthly WHERE id = $1', [req.params.id]);
+    if (!rows.length) {
+      throw notFound('Monthly budget not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/monthly/:id', async (req, res, next) => {
+  try {
+    const payload = monthlyUpdateSchema.parse(req.body);
+    const entries = [];
+    const values = [];
+
+    if (payload.scope !== undefined) {
+      entries.push('scope');
+      values.push(payload.scope);
+    }
+    if (payload.category_id !== undefined) {
+      entries.push('category_id');
+      values.push(payload.category_id);
+    }
+    if (payload.period !== undefined) {
+      entries.push('period_month');
+      values.push(toMonthDate(payload.period));
+    }
+    if (payload.ceiling_amount !== undefined) {
+      entries.push('ceiling_amount');
+      values.push(payload.ceiling_amount);
+    }
+    if (payload.currency_code !== undefined) {
+      entries.push('currency_code');
+      values.push(payload.currency_code);
+    }
+
+    if (!entries.length) {
+      throw new HttpError(400, 'No fields to update');
+    }
+
+    const setClause = entries.map((field, index) => `${field} = $${index + 2}`).join(', ');
+    const query = `UPDATE budget_monthly SET ${setClause} WHERE id = $1 RETURNING *`;
+    const { rows } = await pool.query(query, [req.params.id, ...values]);
+    if (!rows.length) {
+      throw notFound('Monthly budget not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.delete('/monthly/:id', async (req, res, next) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM budget_monthly WHERE id = $1', [req.params.id]);
+    if (!rowCount) {
+      throw notFound('Monthly budget not found');
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/annual', async (req, res, next) => {
+  try {
+    const clauses = [];
+    const values = [];
+
+    if (req.query.scope) {
+      values.push(req.query.scope);
+      clauses.push(`scope = $${values.length}`);
+    }
+    if (req.query.category_id) {
+      const categoryId = Number(req.query.category_id);
+      if (!Number.isInteger(categoryId)) {
+        throw new HttpError(400, 'category_id must be an integer');
+      }
+      values.push(categoryId);
+      clauses.push(`category_id = $${values.length}`);
+    }
+    if (req.query.year) {
+      const year = Number(req.query.year);
+      if (!Number.isInteger(year)) {
+        throw new HttpError(400, 'year must be an integer');
+      }
+      values.push(year);
+      clauses.push(`year = $${values.length}`);
+    }
+
+    let query = 'SELECT * FROM budget_annual';
+    if (clauses.length) {
+      query += ` WHERE ${clauses.join(' AND ')}`;
+    }
+    query += ' ORDER BY year DESC, id DESC';
+
+    const { rows } = await pool.query(query, values);
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/annual', async (req, res, next) => {
+  try {
+    const payload = annualCreateSchema.parse(req.body);
+    const { rows } = await pool.query(
+      `INSERT INTO budget_annual (scope, category_id, year, ceiling_amount, currency_code)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [payload.scope, payload.category_id, payload.year, payload.ceiling_amount, payload.currency_code ?? 'CHF'],
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/annual/:id', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM budget_annual WHERE id = $1', [req.params.id]);
+    if (!rows.length) {
+      throw notFound('Annual budget not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/annual/:id', async (req, res, next) => {
+  try {
+    const payload = annualUpdateSchema.parse(req.body);
+    const entries = [];
+    const values = [];
+
+    if (payload.scope !== undefined) {
+      entries.push('scope');
+      values.push(payload.scope);
+    }
+    if (payload.category_id !== undefined) {
+      entries.push('category_id');
+      values.push(payload.category_id);
+    }
+    if (payload.year !== undefined) {
+      entries.push('year');
+      values.push(payload.year);
+    }
+    if (payload.ceiling_amount !== undefined) {
+      entries.push('ceiling_amount');
+      values.push(payload.ceiling_amount);
+    }
+    if (payload.currency_code !== undefined) {
+      entries.push('currency_code');
+      values.push(payload.currency_code);
+    }
+
+    if (!entries.length) {
+      throw new HttpError(400, 'No fields to update');
+    }
+
+    const setClause = entries.map((field, index) => `${field} = $${index + 2}`).join(', ');
+    const query = `UPDATE budget_annual SET ${setClause} WHERE id = $1 RETURNING *`;
+    const { rows } = await pool.query(query, [req.params.id, ...values]);
+    if (!rows.length) {
+      throw notFound('Annual budget not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.delete('/annual/:id', async (req, res, next) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM budget_annual WHERE id = $1', [req.params.id]);
+    if (!rowCount) {
+      throw notFound('Annual budget not found');
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+export default router;

--- a/backend/src/routes/categories.js
+++ b/backend/src/routes/categories.js
@@ -1,0 +1,111 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { pool } from '../db.js';
+import { HttpError, mapDatabaseError, notFound } from '../errors.js';
+
+const router = Router();
+
+const kindEnum = z.enum(['income', 'expense', 'transfer']);
+
+const baseSchema = z.object({
+  name: z.string().trim().min(1),
+  kind: kindEnum,
+  description: z.string().trim().optional().nullable(),
+});
+
+const createSchema = baseSchema;
+const updateSchema = baseSchema.partial().refine((value) => Object.keys(value).length > 0, {
+  message: 'At least one field must be provided',
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const kindFilter = req.query.kind;
+    let rows;
+    if (kindFilter) {
+      kindEnum.parse(kindFilter);
+      ({ rows } = await pool.query('SELECT * FROM category WHERE kind = $1 ORDER BY name ASC', [kindFilter]));
+    } else {
+      ({ rows } = await pool.query('SELECT * FROM category ORDER BY kind ASC, name ASC'));
+    }
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = createSchema.parse(req.body);
+    const { rows } = await pool.query(
+      `INSERT INTO category (name, kind, description)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [payload.name, payload.kind, payload.description ?? null],
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM category WHERE id = $1', [req.params.id]);
+    if (!rows.length) {
+      throw notFound('Category not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = updateSchema.parse(req.body);
+    const entries = [];
+    const values = [];
+
+    if (payload.name !== undefined) {
+      entries.push('name');
+      values.push(payload.name);
+    }
+    if (payload.kind !== undefined) {
+      entries.push('kind');
+      values.push(payload.kind);
+    }
+    if (payload.description !== undefined) {
+      entries.push('description');
+      values.push(payload.description ?? null);
+    }
+
+    if (!entries.length) {
+      throw new HttpError(400, 'No fields to update');
+    }
+
+    const setClause = entries.map((field, index) => `${field} = $${index + 2}`).join(', ');
+    const query = `UPDATE category SET ${setClause} WHERE id = $1 RETURNING *`;
+    const { rows } = await pool.query(query, [req.params.id, ...values]);
+    if (!rows.length) {
+      throw notFound('Category not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM category WHERE id = $1', [req.params.id]);
+    if (!rowCount) {
+      throw notFound('Category not found');
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+export default router;

--- a/backend/src/routes/persons.js
+++ b/backend/src/routes/persons.js
@@ -1,0 +1,108 @@
+import { Router } from 'express';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { pool } from '../db.js';
+import { HttpError, mapDatabaseError, notFound } from '../errors.js';
+
+const router = Router();
+
+const baseSchema = z.object({
+  name: z.string().trim().min(1),
+  email: z
+    .string()
+    .trim()
+    .email()
+    .optional()
+    .nullable(),
+});
+
+const createSchema = baseSchema.extend({
+  id: z.string().trim().min(1).optional(),
+});
+
+const updateSchema = baseSchema.partial().refine((value) => Object.keys(value).length > 0, {
+  message: 'At least one field must be provided',
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM person ORDER BY created_at ASC');
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = createSchema.parse(req.body);
+    const id = payload.id ?? randomUUID();
+    const { rows } = await pool.query(
+      `INSERT INTO person (id, name, email)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [id, payload.name, payload.email ?? null],
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM person WHERE id = $1', [req.params.id]);
+    if (!rows.length) {
+      throw notFound('Person not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = updateSchema.parse(req.body);
+    const fields = [];
+    const values = [];
+
+    if (payload.name !== undefined) {
+      fields.push('name');
+      values.push(payload.name);
+    }
+
+    if (payload.email !== undefined) {
+      fields.push('email');
+      values.push(payload.email ?? null);
+    }
+
+    if (!fields.length) {
+      throw new HttpError(400, 'No fields to update');
+    }
+
+    const setClauses = fields.map((field, index) => `${field} = $${index + 2}`).join(', ');
+    const query = `UPDATE person SET ${setClauses} WHERE id = $1 RETURNING *`;
+    const { rows } = await pool.query(query, [req.params.id, ...values]);
+    if (!rows.length) {
+      throw notFound('Person not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM person WHERE id = $1', [req.params.id]);
+    if (!rowCount) {
+      throw notFound('Person not found');
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -1,0 +1,130 @@
+import { Router } from 'express';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { pool } from '../db.js';
+import { HttpError, mapDatabaseError, notFound } from '../errors.js';
+
+const router = Router();
+
+const baseSchema = z.object({
+  name: z.string().trim().min(1),
+  description: z.string().trim().optional().nullable(),
+  target_amount: z.number().finite().optional(),
+  budget_amount: z.number().finite().optional(),
+  start_date: z.coerce.date().optional(),
+  end_date: z.coerce.date().optional(),
+});
+
+const createSchema = baseSchema.extend({
+  id: z.string().trim().min(1).optional(),
+});
+
+const updateSchema = baseSchema.partial().refine((value) => Object.keys(value).length > 0, {
+  message: 'At least one field must be provided',
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM project ORDER BY created_at ASC');
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = createSchema.parse(req.body);
+    const id = payload.id ?? randomUUID();
+    const { rows } = await pool.query(
+      `INSERT INTO project (id, name, description, target_amount, budget_amount, start_date, end_date)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        id,
+        payload.name,
+        payload.description ?? null,
+        payload.target_amount ?? null,
+        payload.budget_amount ?? null,
+        payload.start_date ?? null,
+        payload.end_date ?? null,
+      ],
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM project WHERE id = $1', [req.params.id]);
+    if (!rows.length) {
+      throw notFound('Project not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = updateSchema.parse(req.body);
+    const entries = [];
+    const values = [];
+
+    if (payload.name !== undefined) {
+      entries.push('name');
+      values.push(payload.name);
+    }
+    if (payload.description !== undefined) {
+      entries.push('description');
+      values.push(payload.description ?? null);
+    }
+    if (payload.target_amount !== undefined) {
+      entries.push('target_amount');
+      values.push(payload.target_amount ?? null);
+    }
+    if (payload.budget_amount !== undefined) {
+      entries.push('budget_amount');
+      values.push(payload.budget_amount ?? null);
+    }
+    if (payload.start_date !== undefined) {
+      entries.push('start_date');
+      values.push(payload.start_date ?? null);
+    }
+    if (payload.end_date !== undefined) {
+      entries.push('end_date');
+      values.push(payload.end_date ?? null);
+    }
+
+    if (!entries.length) {
+      throw new HttpError(400, 'No fields to update');
+    }
+
+    const setClause = entries.map((field, index) => `${field} = $${index + 2}`).join(', ');
+    const query = `UPDATE project SET ${setClause} WHERE id = $1 RETURNING *`;
+    const { rows } = await pool.query(query, [req.params.id, ...values]);
+    if (!rows.length) {
+      throw notFound('Project not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM project WHERE id = $1', [req.params.id]);
+    if (!rowCount) {
+      throw notFound('Project not found');
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+export default router;

--- a/backend/src/routes/provisions.js
+++ b/backend/src/routes/provisions.js
@@ -1,0 +1,267 @@
+import { Router } from 'express';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { pool, withTransaction } from '../db.js';
+import { HttpError, mapDatabaseError, notFound } from '../errors.js';
+
+const router = Router();
+
+const baseSchema = z.object({
+  name: z.string().trim().min(1),
+  description: z.string().trim().optional().nullable(),
+  target_amount: z.number().finite().optional(),
+  category_id: z.number().int().positive().optional(),
+});
+
+const createSchema = baseSchema.extend({
+  id: z.string().trim().min(1).optional(),
+});
+
+const updateSchema = baseSchema.partial().refine((value) => Object.keys(value).length > 0, {
+  message: 'At least one field must be provided',
+});
+
+const ledgerActionSchema = z.object({
+  amount: z.number().positive(),
+  occurred_on: z.coerce.date(),
+  note: z.string().trim().optional().nullable(),
+  transaction_id: z.number().int().positive().optional(),
+});
+
+const transferSchema = ledgerActionSchema.extend({
+  to_provision_id: z.string().trim().min(1),
+});
+
+const cancelSchema = z.object({
+  ledger_entry_id: z.number().int().positive(),
+  note: z.string().trim().optional().nullable(),
+  occurred_on: z.coerce.date().optional(),
+});
+
+async function ensureProvisionExists(id) {
+  const { rows } = await pool.query('SELECT id FROM provision WHERE id = $1', [id]);
+  if (!rows.length) {
+    throw notFound('Provision not found');
+  }
+  return rows[0];
+}
+
+router.get('/', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM provision ORDER BY created_at ASC');
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = createSchema.parse(req.body);
+    const id = payload.id ?? randomUUID();
+    const { rows } = await pool.query(
+      `INSERT INTO provision (id, name, description, target_amount, category_id)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [id, payload.name, payload.description ?? null, payload.target_amount ?? null, payload.category_id ?? null],
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM provision WHERE id = $1', [req.params.id]);
+    if (!rows.length) {
+      throw notFound('Provision not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = updateSchema.parse(req.body);
+    const entries = [];
+    const values = [];
+
+    if (payload.name !== undefined) {
+      entries.push('name');
+      values.push(payload.name);
+    }
+    if (payload.description !== undefined) {
+      entries.push('description');
+      values.push(payload.description ?? null);
+    }
+    if (payload.target_amount !== undefined) {
+      entries.push('target_amount');
+      values.push(payload.target_amount ?? null);
+    }
+    if (payload.category_id !== undefined) {
+      entries.push('category_id');
+      values.push(payload.category_id ?? null);
+    }
+
+    if (!entries.length) {
+      throw new HttpError(400, 'No fields to update');
+    }
+
+    const setClause = entries.map((field, index) => `${field} = $${index + 2}`).join(', ');
+    const query = `UPDATE provision SET ${setClause} WHERE id = $1 RETURNING *`;
+    const { rows } = await pool.query(query, [req.params.id, ...values]);
+    if (!rows.length) {
+      throw notFound('Provision not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM provision WHERE id = $1', [req.params.id]);
+    if (!rowCount) {
+      throw notFound('Provision not found');
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/:id/ledger', async (req, res, next) => {
+  try {
+    await ensureProvisionExists(req.params.id);
+    const { rows } = await pool.query(
+      'SELECT * FROM provision_ledger WHERE provision_id = $1 ORDER BY occurred_on DESC, id DESC',
+      [req.params.id],
+    );
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/:id/fund', async (req, res, next) => {
+  try {
+    const payload = ledgerActionSchema.parse(req.body);
+    await ensureProvisionExists(req.params.id);
+    const { rows } = await pool.query(
+      `INSERT INTO provision_ledger (provision_id, transaction_id, entry_kind, amount, occurred_on, note)
+       VALUES ($1, $2, 'fund', $3, $4, $5)
+       RETURNING *`,
+      [req.params.id, payload.transaction_id ?? null, payload.amount, payload.occurred_on, payload.note ?? null],
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.post('/:id/consume', async (req, res, next) => {
+  try {
+    const payload = ledgerActionSchema.parse(req.body);
+    await ensureProvisionExists(req.params.id);
+    const { rows } = await pool.query(
+      `INSERT INTO provision_ledger (provision_id, transaction_id, entry_kind, amount, occurred_on, note)
+       VALUES ($1, $2, 'consume', $3, $4, $5)
+       RETURNING *`,
+      [req.params.id, payload.transaction_id ?? null, payload.amount, payload.occurred_on, payload.note ?? null],
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.post('/:id/transfer', async (req, res, next) => {
+  try {
+    const payload = transferSchema.parse(req.body);
+    const occurredOn = payload.occurred_on;
+    const note = payload.note ?? null;
+
+    const result = await withTransaction(async (client) => {
+      const source = await client.query('SELECT id FROM provision WHERE id = $1', [req.params.id]);
+      if (!source.rows.length) {
+        throw notFound('Provision not found');
+      }
+      const target = await client.query('SELECT id FROM provision WHERE id = $1', [payload.to_provision_id]);
+      if (!target.rows.length) {
+        throw notFound('Target provision not found');
+      }
+
+      const debit = await client.query(
+        `INSERT INTO provision_ledger (provision_id, transaction_id, entry_kind, amount, occurred_on, note)
+         VALUES ($1, $2, 'adjust', $3, $4, $5)
+         RETURNING *`,
+        [
+          req.params.id,
+          payload.transaction_id ?? null,
+          -payload.amount,
+          occurredOn,
+          note ?? `Transfer to ${payload.to_provision_id}`,
+        ],
+      );
+
+      const credit = await client.query(
+        `INSERT INTO provision_ledger (provision_id, transaction_id, entry_kind, amount, occurred_on, note)
+         VALUES ($1, $2, 'adjust', $3, $4, $5)
+         RETURNING *`,
+        [
+          payload.to_provision_id,
+          payload.transaction_id ?? null,
+          payload.amount,
+          occurredOn,
+          note ?? `Transfer from ${req.params.id}`,
+        ],
+      );
+
+      return { debit: debit.rows[0], credit: credit.rows[0] };
+    });
+    res.status(201).json(result);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.post('/:id/cancel', async (req, res, next) => {
+  try {
+    const payload = cancelSchema.parse(req.body);
+    const occurredOn = payload.occurred_on ?? new Date();
+
+    const { rows } = await pool.query(
+      'SELECT * FROM provision_ledger WHERE id = $1 AND provision_id = $2',
+      [payload.ledger_entry_id, req.params.id],
+    );
+    if (!rows.length) {
+      throw notFound('Ledger entry not found for this provision');
+    }
+
+    const original = rows[0];
+    const amount = Number(original.amount) * -1;
+
+    const { rows: insertRows } = await pool.query(
+      `INSERT INTO provision_ledger (provision_id, transaction_id, entry_kind, amount, occurred_on, note)
+       VALUES ($1, $2, 'adjust', $3, $4, $5)
+       RETURNING *`,
+      [
+        req.params.id,
+        original.transaction_id ?? null,
+        amount,
+        occurredOn,
+        payload.note ?? `Cancellation of ledger ${original.id}`,
+      ],
+    );
+
+    res.status(201).json(insertRows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+export default router;

--- a/backend/src/routes/rules.js
+++ b/backend/src/routes/rules.js
@@ -1,0 +1,164 @@
+import { Router } from 'express';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { pool, withTransaction } from '../db.js';
+import { HttpError, mapDatabaseError, notFound } from '../errors.js';
+
+const router = Router();
+
+const targetKind = z.enum(['income', 'expense']);
+
+const baseSchema = z.object({
+  target_kind: targetKind,
+  category_id: z.number().int().positive(),
+  keywords: z.array(z.string().trim().min(1)).default([]),
+  priority: z.number().int().optional(),
+  enabled: z.boolean().optional(),
+});
+
+const createSchema = baseSchema.extend({
+  id: z.string().trim().min(1).optional(),
+});
+
+const updateSchema = baseSchema.partial().refine((value) => Object.keys(value).length > 0, {
+  message: 'At least one field must be provided',
+});
+
+const reorderSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        id: z.string().trim().min(1),
+        priority: z.number().int(),
+      }),
+    )
+    .min(1),
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const whereClauses = [];
+    const values = [];
+
+    if (req.query.target_kind) {
+      targetKind.parse(req.query.target_kind);
+      values.push(req.query.target_kind);
+      whereClauses.push(`target_kind = $${values.length}`);
+    }
+
+    if (req.query.enabled !== undefined) {
+      const enabled = req.query.enabled === 'true';
+      values.push(enabled);
+      whereClauses.push(`enabled = $${values.length}`);
+    }
+
+    const where = whereClauses.length ? `WHERE ${whereClauses.join(' AND ')}` : '';
+    const query = `SELECT * FROM rule ${where} ORDER BY priority DESC, created_at ASC`;
+    const { rows } = await pool.query(query, values);
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = createSchema.parse(req.body);
+    const id = payload.id ?? randomUUID();
+    const { rows } = await pool.query(
+      `INSERT INTO rule (id, target_kind, category_id, keywords, priority, enabled)
+       VALUES ($1, $2, $3, $4, COALESCE($5, 0), COALESCE($6, TRUE))
+       RETURNING *`,
+      [id, payload.target_kind, payload.category_id, payload.keywords, payload.priority ?? null, payload.enabled ?? null],
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM rule WHERE id = $1', [req.params.id]);
+    if (!rows.length) {
+      throw notFound('Rule not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = updateSchema.parse(req.body);
+    const entries = [];
+    const values = [];
+
+    if (payload.target_kind !== undefined) {
+      entries.push('target_kind');
+      values.push(payload.target_kind);
+    }
+    if (payload.category_id !== undefined) {
+      entries.push('category_id');
+      values.push(payload.category_id);
+    }
+    if (payload.keywords !== undefined) {
+      entries.push('keywords');
+      values.push(payload.keywords);
+    }
+    if (payload.priority !== undefined) {
+      entries.push('priority');
+      values.push(payload.priority);
+    }
+    if (payload.enabled !== undefined) {
+      entries.push('enabled');
+      values.push(payload.enabled);
+    }
+
+    if (!entries.length) {
+      throw new HttpError(400, 'No fields to update');
+    }
+
+    const setClause = entries.map((field, index) => `${field} = $${index + 2}`).join(', ');
+    const query = `UPDATE rule SET ${setClause} WHERE id = $1 RETURNING *`;
+    const { rows } = await pool.query(query, [req.params.id, ...values]);
+    if (!rows.length) {
+      throw notFound('Rule not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM rule WHERE id = $1', [req.params.id]);
+    if (!rowCount) {
+      throw notFound('Rule not found');
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.post('/reorder', async (req, res, next) => {
+  try {
+    const payload = reorderSchema.parse(req.body);
+    await withTransaction(async (client) => {
+      for (const item of payload.items) {
+        const { rowCount } = await client.query('UPDATE rule SET priority = $2 WHERE id = $1', [item.id, item.priority]);
+        if (!rowCount) {
+          throw notFound(`Rule ${item.id} not found`);
+        }
+      }
+    });
+    res.json({ updated: payload.items.length });
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+export default router;

--- a/backend/src/routes/transactions.js
+++ b/backend/src/routes/transactions.js
@@ -1,0 +1,184 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { pool } from '../db.js';
+import { HttpError, mapDatabaseError, notFound } from '../errors.js';
+
+const router = Router();
+
+const currencyRegex = /^[A-Z]{3}$/;
+const dateSchema = z.coerce.date({ required_error: 'occurred_on is required' });
+
+const baseSchema = z.object({
+  account_id: z.string().trim().min(1),
+  import_batch_id: z.number().int().positive().optional(),
+  rule_id: z.string().trim().min(1).optional(),
+  project_id: z.string().trim().min(1).optional(),
+  category_id: z.number().int().positive().optional(),
+  external_id: z.string().trim().optional().nullable(),
+  occurred_on: dateSchema,
+  value_date: z.coerce.date().optional(),
+  amount: z.number().finite(),
+  currency_code: z
+    .string()
+    .trim()
+    .regex(currencyRegex, 'Currency must be a 3-letter ISO code')
+    .default('CHF'),
+  description: z.string().trim().min(1),
+  raw_description: z.string().trim().optional().nullable(),
+  balance_after: z.number().finite().optional(),
+});
+
+const createSchema = baseSchema;
+const updateSchema = baseSchema.partial().refine((value) => Object.keys(value).length > 0, {
+  message: 'At least one field must be provided',
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const clauses = [];
+    const values = [];
+
+    if (req.query.account_id) {
+      values.push(req.query.account_id);
+      clauses.push(`account_id = $${values.length}`);
+    }
+
+    if (req.query.category_id) {
+      const categoryId = Number(req.query.category_id);
+      if (!Number.isInteger(categoryId)) {
+        throw new HttpError(400, 'category_id must be an integer');
+      }
+      values.push(categoryId);
+      clauses.push(`category_id = $${values.length}`);
+    }
+
+    let query = 'SELECT * FROM transaction';
+    if (clauses.length) {
+      query += ` WHERE ${clauses.join(' AND ')}`;
+    }
+    query += ' ORDER BY occurred_on DESC, id DESC';
+
+    if (req.query.limit) {
+      const limit = Number(req.query.limit);
+      if (!Number.isInteger(limit) || limit <= 0) {
+        throw new HttpError(400, 'limit must be a positive integer');
+      }
+      values.push(limit);
+      query += ` LIMIT $${values.length}`;
+    }
+
+    if (req.query.offset) {
+      const offset = Number(req.query.offset);
+      if (!Number.isInteger(offset) || offset < 0) {
+        throw new HttpError(400, 'offset must be a non-negative integer');
+      }
+      values.push(offset);
+      query += ` OFFSET $${values.length}`;
+    }
+
+    const { rows } = await pool.query(query, values);
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = createSchema.parse(req.body);
+    const values = [
+      payload.account_id,
+      payload.import_batch_id ?? null,
+      payload.rule_id ?? null,
+      payload.project_id ?? null,
+      payload.category_id ?? null,
+      payload.external_id ?? null,
+      payload.occurred_on,
+      payload.value_date ?? null,
+      payload.amount,
+      payload.currency_code ?? 'CHF',
+      payload.description,
+      payload.raw_description ?? null,
+      payload.balance_after ?? null,
+    ];
+    const { rows } = await pool.query(
+      `INSERT INTO transaction (
+         account_id, import_batch_id, rule_id, project_id, category_id, external_id,
+         occurred_on, value_date, amount, currency_code, description, raw_description, balance_after
+       )
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+       RETURNING *`,
+      values,
+    );
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM transaction WHERE id = $1', [req.params.id]);
+    if (!rows.length) {
+      throw notFound('Transaction not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = updateSchema.parse(req.body);
+    const entries = [];
+    const values = [];
+
+    const add = (field, value) => {
+      entries.push(field);
+      values.push(value);
+    };
+
+    if (payload.account_id !== undefined) add('account_id', payload.account_id);
+    if (payload.import_batch_id !== undefined) add('import_batch_id', payload.import_batch_id ?? null);
+    if (payload.rule_id !== undefined) add('rule_id', payload.rule_id ?? null);
+    if (payload.project_id !== undefined) add('project_id', payload.project_id ?? null);
+    if (payload.category_id !== undefined) add('category_id', payload.category_id ?? null);
+    if (payload.external_id !== undefined) add('external_id', payload.external_id ?? null);
+    if (payload.occurred_on !== undefined) add('occurred_on', payload.occurred_on);
+    if (payload.value_date !== undefined) add('value_date', payload.value_date ?? null);
+    if (payload.amount !== undefined) add('amount', payload.amount);
+    if (payload.currency_code !== undefined) add('currency_code', payload.currency_code);
+    if (payload.description !== undefined) add('description', payload.description);
+    if (payload.raw_description !== undefined) add('raw_description', payload.raw_description ?? null);
+    if (payload.balance_after !== undefined) add('balance_after', payload.balance_after ?? null);
+
+    if (!entries.length) {
+      throw new HttpError(400, 'No fields to update');
+    }
+
+    const setClause = entries.map((field, index) => `${field} = $${index + 2}`).join(', ');
+    const query = `UPDATE transaction SET ${setClause} WHERE id = $1 RETURNING *`;
+    const { rows } = await pool.query(query, [req.params.id, ...values]);
+    if (!rows.length) {
+      throw notFound('Transaction not found');
+    }
+    res.json(rows[0]);
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM transaction WHERE id = $1', [req.params.id]);
+    if (!rowCount) {
+      throw notFound('Transaction not found');
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(mapDatabaseError(error));
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,8 @@
+import { createApp } from './app.js';
+
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+const app = createApp();
+
+app.listen(port, () => {
+  console.log(`Budget API listening on port ${port}`);
+});

--- a/docs/postman/Budget-API.postman_collection.json
+++ b/docs/postman/Budget-API.postman_collection.json
@@ -1,0 +1,60 @@
+{
+  "info": {
+    "name": "Budget API Lot 2",
+    "description": "Collection Postman pour l'API Budget (Lot 2)",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Health",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/health",
+          "host": ["{{baseUrl}}"],
+          "path": ["health"]
+        }
+      }
+    },
+    {
+      "name": "List persons",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/persons",
+          "host": ["{{baseUrl}}"],
+          "path": ["persons"]
+        }
+      }
+    },
+    {
+      "name": "Create transaction",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"account_id\": \"a1\",\n  \"occurred_on\": \"2025-01-05\",\n  \"amount\": -85.4,\n  \"description\": \"Courses Migros\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/transactions",
+          "host": ["{{baseUrl}}"],
+          "path": ["transactions"]
+        }
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3000"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add an Express-based REST API wired to the existing PostgreSQL schema (persons, accounts, categories, rules with reorder, transactions, provisions actions, projects, monthly and annual budgets)
- share database bootstrap and HTTP error helpers with runtime validation via Zod across the new routers
- document the API usage with curl/Postman examples, provide a Postman collection, and expose an `npm run dev` command for local development

## Testing
- npm install *(fails: 403 Forbidden from registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b68f273083249d58d4164efd3c8d