### PR TITLE
Lot 5 — Frontend Import (upload réel + rapport enrichi)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:3000
+VITE_UPLOAD_ENABLED=0

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,20 +1,39 @@
-# Lot 4 – Frontend (Budget2)
+# Lot 5 – Frontend Import (upload réel + rapport)
 
-## Objectif
-Interface minimale pour tester l’API backend :
-- `GET /health` (section Santé)
-- `POST /imports/excel` puis `GET /imports/:id` (section Imports)
+## Variables d'environnement
+- `VITE_API_URL` (par défaut `http://localhost:3000`)
+- `VITE_UPLOAD_ENABLED` (0 = stub / 1 = UI fichier)
 
-## Démarrage
-```bash
-npm install
-cp .env.example .env  # si nécessaire
-npm run dev
-```
+## Lancer en mode stub (CI/dev)
+Backend :
 
-Ouvrir l’URL affichée (ex: http://localhost:5173).
-Configurer `VITE_API_URL` si le backend n’est pas sur http://localhost:3000.
+
+set DISABLE_DB=1 && npm run dev
+
+Frontend :
+
+
+set VITE_UPLOAD_ENABLED=0 && npm run dev
+
+
+## Lancer en mode upload réel (local)
+Backend :
+
+
+set ENABLE_UPLOAD=1 && set ENABLE_XLSX=1 && npm run dev
+
+Frontend :
+
+
+set VITE_UPLOAD_ENABLED=1 && npm run dev
+
+
+## Flux
+1. Créer un import (POST /imports/excel) :
+   - avec fichier .xlsx si UI upload active,
+   - sinon fallback stub.
+2. Récupérer le rapport (GET /imports/:id) et afficher les cartes + JSON.
 
 ## Notes
-- Compatible mode stub hors-DB (backend avec `DISABLE_DB=1`).
-- Pas d’upload de fichier pour l’instant (sera ajouté plus tard).
+- Aucune dépendance supplémentaire (fetch natif, Tailwind).
+- Les erreurs réseau et validations sont affichées sous le bloc Import.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { getHealth, postImportExcel, getImport } from './api'
+import { useEffect, useMemo, useState } from 'react'
+import { getHealth, postImportExcelStub, postImportExcelFile, getImportReport } from './api'
 
 function Badge({ ok }) {
   return (
@@ -9,26 +9,91 @@ function Badge({ ok }) {
   )
 }
 
+function Card({ title, children, right }) {
+  return (
+    <section className="bg-white rounded-xl shadow p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold">{title}</h2>
+        {right || null}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function KeyVal({ k, v }) {
+  return (
+    <div className="flex gap-2 text-sm">
+      <div className="w-40 text-gray-600">{k}</div>
+      <div className="font-medium">{v ?? '-'}</div>
+    </div>
+  )
+}
+
+function Table({ headers, rows, emptyLabel = 'Aucune donnée' }) {
+  return (
+    <div className="overflow-auto border rounded">
+      <table className="min-w-full text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            {headers.map((h, i) => (
+              <th key={i} className="text-left px-3 py-2 font-semibold text-gray-700">{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 ? (
+            <tr><td className="px-3 py-2 text-gray-500" colSpan={headers.length}>{emptyLabel}</td></tr>
+          ) : rows.map((r, i) => (
+            <tr key={i} className="border-t">
+              {r.map((c, j) => (<td key={j} className="px-3 py-2">{c}</td>))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 export default function App() {
   const [health, setHealth] = useState(null)
-  const [busy, setBusy] = useState(false)
   const [err, setErr] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const [file, setFile] = useState(null)
+  const uploadEnabled = import.meta.env.VITE_UPLOAD_ENABLED === '1'
+
   const [postResp, setPostResp] = useState(null)
   const [batchId, setBatchId] = useState('')
-  const [getResp, setGetResp] = useState(null)
+  const [report, setReport] = useState(null)
 
   useEffect(() => {
     getHealth().then(setHealth).catch(e => setErr(e.message))
   }, [])
 
   async function handleCreateImport() {
-    setErr(''); setBusy(true); setGetResp(null)
+    setErr('')
+    setBusy(true)
+    setReport(null)
+
     try {
-      const data = await postImportExcel()
+      let data
+      if (uploadEnabled && file) {
+        // Upload réel
+        if (!file.name.toLowerCase().endsWith('.xlsx')) {
+          throw new Error('Un fichier .xlsx est attendu.')
+        }
+        data = await postImportExcelFile(file)
+      } else {
+        // Fallback stub
+        data = await postImportExcelStub()
+      }
       setPostResp(data)
-      if (data?.import_batch_id) setBatchId(String(data.import_batch_id))
+      if (data?.import_batch_id) {
+        setBatchId(String(data.import_batch_id))
+      }
     } catch (e) {
-      setErr(e.message)
+      setErr(e.message || String(e))
     } finally {
       setBusy(false)
     }
@@ -36,102 +101,175 @@ export default function App() {
 
   async function handleFetchReport() {
     if (!batchId) return
-    setErr(''); setBusy(true)
+    setErr('')
+    setBusy(true)
     try {
-      const data = await getImport(batchId)
-      setGetResp(data)
+      const data = await getImportReport(batchId)
+      setReport(data)
     } catch (e) {
-      setErr(e.message)
+      setErr(e.message || String(e))
     } finally {
       setBusy(false)
     }
   }
 
+  const categoriesRows = useMemo(() => {
+    const cats = report?.report?.categories || []
+    return cats.map(c => [c.name, c.kind, c.count])
+  }, [report])
+
+  const accountsRows = useMemo(() => {
+    const accs = report?.report?.accounts || []
+    return accs.map(a => [a.name || '-', a.iban || '-', a.created ?? '-'])
+  }, [report])
+
+  const totals = report?.report?.totals || {}
+  const ignored = report?.report?.ignored || {}
+  const balances = report?.report?.balances || {}
+
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900">
-      <div className="max-w-4xl mx-auto p-6 space-y-6">
-        <h1 className="text-2xl font-bold">Budget — Frontend (Lot 4)</h1>
+      <div className="max-w-5xl mx-auto p-6 space-y-6">
+        <h1 className="text-2xl font-bold">Budget — Frontend (Lot 5)</h1>
 
-        {/* Santé */}
-        <section className="bg-white rounded-xl shadow p-4 space-y-2">
-          <div className="flex items-center justify-between">
-            <h2 className="font-semibold">Santé backend</h2>
-            <Badge ok={health?.status === 'ok'} />
-          </div>
+        <Card title="Santé backend" right={<Badge ok={health?.status === 'ok'} />}>
           <pre className="text-sm bg-gray-100 p-3 rounded overflow-auto">
             {JSON.stringify(health, null, 2)}
           </pre>
-        </section>
+        </Card>
 
-        {/* Imports */}
-        <section className="bg-white rounded-xl shadow p-4 space-y-4">
-          <div className="flex items-center justify-between">
-            <h2 className="font-semibold">Import Excel (stub compatible)</h2>
-            {busy ? <span className="text-sm">⏳</span> : null}
-          </div>
+        <Card
+          title="Import Excel"
+          right={<span className="text-sm px-2 py-1 rounded bg-indigo-50 text-indigo-700">
+            {uploadEnabled ? 'Upload réel (si backend ENABLE_UPLOAD/ENABLE_XLSX)' : 'Mode stub (pas de fichier requis)'}
+          </span>}
+        >
+          <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+            <div className="space-y-3">
+              {uploadEnabled && (
+                <input
+                  type="file"
+                  accept=".xlsx"
+                  onChange={e => setFile(e.target.files?.[0] || null)}
+                  className="block w-full text-sm file:mr-3 file:py-2 file:px-3 file:rounded file:border-0 file:bg-blue-600 file:text-white hover:file:bg-blue-700"
+                />
+              )}
 
-          <div className="flex flex-wrap gap-2">
-            <button
-              className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
-              onClick={handleCreateImport}
-              disabled={busy}
-            >
-              Créer un import (POST /imports/excel)
-            </button>
+              <div className="flex gap-2 flex-wrap">
+                <button
+                  onClick={handleCreateImport}
+                  disabled={busy || (uploadEnabled && !file)}
+                  className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                  Créer un import (POST /imports/excel)
+                </button>
 
-            <input
-              className="border rounded px-3 py-2 w-48"
-              placeholder="import_batch_id"
-              value={batchId}
-              onChange={e => setBatchId(e.target.value)}
-            />
+                <input
+                  className="border rounded px-3 py-2 w-48"
+                  placeholder="import_batch_id"
+                  value={batchId}
+                  onChange={e => setBatchId(e.target.value)}
+                />
 
-            <button
-              className="px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50"
-              onClick={handleFetchReport}
-              disabled={busy || !batchId}
-            >
-              Récupérer le rapport (GET /imports/:id)
-            </button>
-          </div>
+                <button
+                  onClick={handleFetchReport}
+                  disabled={busy || !batchId}
+                  className="px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50"
+                >
+                  Récupérer le rapport (GET /imports/:id)
+                </button>
+              </div>
 
-          {err ? <p className="text-sm text-red-600">Erreur : {err}</p> : null}
+              {err ? <p className="text-sm text-red-600">Erreur : {err}</p> : null}
 
-          {postResp && (
-            <div>
-              <h3 className="font-medium">Réponse POST</h3>
-              <pre className="text-sm bg-gray-100 p-3 rounded overflow-auto">
-                {JSON.stringify(postResp, null, 2)}
-              </pre>
-            </div>
-          )}
-
-          {getResp && (
-            <div>
-              <h3 className="font-medium">Rapport</h3>
-              <div className="text-sm grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="bg-gray-50 p-3 rounded">
-                  <div className="font-semibold">Totals</div>
-                  <ul className="list-disc ms-5">
-                    <li>parsed: {getResp.report?.totals?.parsed ?? '-'}</li>
-                    <li>created: {getResp.report?.totals?.created ?? '-'}</li>
-                  </ul>
+              {postResp && (
+                <div className="space-y-2">
+                  <h3 className="font-medium">Réponse POST</h3>
+                  <pre className="text-sm bg-gray-100 p-3 rounded overflow-auto">
+                    {JSON.stringify(postResp, null, 2)}
+                  </pre>
                 </div>
-                <div className="bg-gray-50 p-3 rounded">
-                  <div className="font-semibold">Ignored</div>
-                  <ul className="list-disc ms-5">
-                    <li>duplicates: {getResp.report?.ignored?.duplicates ?? '-'}</li>
-                    <li>missing_account: {getResp.report?.ignored?.missing_account ?? '-'}</li>
-                    <li>invalid: {getResp.report?.ignored?.invalid ?? '-'}</li>
-                  </ul>
+              )}
+            </div>
+
+            {/* Résumé instantané */}
+            <div className="bg-gray-50 rounded p-3 h-max">
+              <div className="font-semibold mb-2">Résumé</div>
+              <KeyVal k="import_batch_id" v={postResp?.import_batch_id} />
+              <KeyVal k="totals.parsed" v={postResp?.report?.totals?.parsed} />
+              <KeyVal k="totals.created" v={postResp?.report?.totals?.created} />
+              <KeyVal k="ignored.total" v={
+                (postResp?.report?.ignored?.duplicates ?? 0) +
+                (postResp?.report?.ignored?.missing_account ?? 0) +
+                (postResp?.report?.ignored?.invalid ?? 0)
+              } />
+            </div>
+          </div>
+        </Card>
+
+        {report && (
+          <Card title="Rapport d'import">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="bg-gray-50 p-3 rounded">
+                <div className="font-semibold mb-2">Totals</div>
+                <ul className="list-disc ms-5 text-sm">
+                  <li>parsed: {totals.parsed ?? '-'}</li>
+                  <li>created: {totals.created ?? '-'}</li>
+                </ul>
+              </div>
+
+              <div className="bg-gray-50 p-3 rounded">
+                <div className="font-semibold mb-2">Ignored</div>
+                <ul className="list-disc ms-5 text-sm">
+                  <li>duplicates: {ignored.duplicates ?? '-'}</li>
+                  <li>missing_account: {ignored.missing_account ?? '-'}</li>
+                  <li>invalid: {ignored.invalid ?? '-'}</li>
+                </ul>
+              </div>
+
+              <div className="bg-gray-50 p-3 rounded md:col-span-2">
+                <div className="font-semibold mb-2">Categories</div>
+                <Table
+                  headers={['Name', 'Kind', 'Count']}
+                  rows={(categoriesRows || []).sort((a, b) => (b[2] ?? 0) - (a[2] ?? 0))}
+                  emptyLabel="Aucune catégorie"
+                />
+              </div>
+
+              <div className="bg-gray-50 p-3 rounded md:col-span-2">
+                <div className="font-semibold mb-2">Accounts</div>
+                <Table
+                  headers={['Name', 'IBAN', 'Created']}
+                  rows={accountsRows || []}
+                  emptyLabel="Aucun compte"
+                />
+              </div>
+
+              <div className="bg-gray-50 p-3 rounded md:col-span-2">
+                <div className="font-semibold mb-2">Balances</div>
+                <div className="grid md:grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <div className="font-medium mb-1">Expected</div>
+                    <KeyVal k="start" v={balances?.expected?.start} />
+                    <KeyVal k="end" v={balances?.expected?.end} />
+                  </div>
+                  <div>
+                    <div className="font-medium mb-1">Actual</div>
+                    <KeyVal k="start" v={balances?.actual?.start} />
+                    <KeyVal k="end" v={balances?.actual?.end} />
+                  </div>
                 </div>
               </div>
-              <pre className="text-sm bg-gray-100 p-3 rounded overflow-auto mt-3">
-                {JSON.stringify(getResp, null, 2)}
-              </pre>
             </div>
-          )}
-        </section>
+
+            <details className="mt-3">
+              <summary className="cursor-pointer select-none text-sm text-gray-700">Voir le JSON brut</summary>
+              <pre className="text-xs bg-gray-100 p-3 rounded overflow-auto mt-2">
+                {JSON.stringify(report, null, 2)}
+              </pre>
+            </details>
+          </Card>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,27 +1,41 @@
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3000').replace(/\/+$/, '');
 
-async function jsonOrThrow(res, fallbackMsg) {
-  let data = null
-  try { data = await res.json() } catch {}
-  if (!res.ok) {
-    const msg = (data && (data.error || data.message)) || `${fallbackMsg} (${res.status})`
-    throw new Error(msg)
+async function jsonOrThrow(res, label) {
+  let data = null;
+  try {
+    data = await res.json();
+  } catch {
+    // ignore
   }
-  return data
+  if (!res.ok) {
+    const msg =
+      (data && (data.error || data.message)) ||
+      `${label}: ${res.status} ${res.statusText}`;
+    throw new Error(msg);
+  }
+  return data;
 }
 
 export async function getHealth() {
-  const res = await fetch(`${API_URL}/health`)
-  return jsonOrThrow(res, 'Health failed')
+  const res = await fetch(`${API_URL}/health`);
+  return jsonOrThrow(res, 'GET /health failed');
 }
 
-export async function postImportExcel() {
-  // En mode stub (backend DISABLE_DB=1), aucun fichier n’est requis.
-  const res = await fetch(`${API_URL}/imports/excel`, { method: 'POST' })
-  return jsonOrThrow(res, 'POST /imports/excel failed')
+export async function postImportExcelStub() {
+  // Appel sans fichier (mode stub)
+  const res = await fetch(`${API_URL}/imports/excel`, { method: 'POST' });
+  return jsonOrThrow(res, 'POST /imports/excel (stub) failed');
 }
 
-export async function getImport(id) {
-  const res = await fetch(`${API_URL}/imports/${id}`)
-  return jsonOrThrow(res, `GET /imports/${id} failed`)
+export async function postImportExcelFile(file) {
+  // Upload réel en multipart
+  const fd = new FormData();
+  fd.append('file', file);
+  const res = await fetch(`${API_URL}/imports/excel`, { method: 'POST', body: fd });
+  return jsonOrThrow(res, 'POST /imports/excel (upload) failed');
+}
+
+export async function getImportReport(id) {
+  const res = await fetch(`${API_URL}/imports/${encodeURIComponent(id)}`);
+  return jsonOrThrow(res, `GET /imports/${id} failed`);
 }


### PR DESCRIPTION
## Objet
Mettre à jour l’interface du lot frontend pour gérer l’upload Excel réel et enrichir l’affichage du rapport d’import.

## Changements
- Ajout de la variable `VITE_UPLOAD_ENABLED` dans l’exemple d’environnement.
- Nouveau client API avec endpoints stub et multipart et récupération du rapport détaillé.
- Refacto de l’UI d’import : support upload `.xlsx`, cartes Totals/Ignored/Categories/Accounts/Balances, résumé et viewer JSON.
- README mis à jour avec les scénarios stub et upload réel.

## Activation / Lancement
### Mode stub (CI/dev)
Backend :
```
set DISABLE_DB=1 && npm run dev
```
Frontend :
```
set VITE_UPLOAD_ENABLED=0 && npm run dev
```

### Mode upload réel (local)
Backend :
```
set ENABLE_UPLOAD=1 && set ENABLE_XLSX=1 && npm run dev
```
Frontend :
```
set VITE_UPLOAD_ENABLED=1 && npm run dev
```

## UAT
- A) Stub (sans fichier)
  - Frontend `VITE_UPLOAD_ENABLED=0`, Backend `DISABLE_DB=1`.
  - POST `/imports/excel` → 201 avec `import_batch_id > 0` + `report`.
  - GET `/imports/:id` → cartes Totals / Ignored / Categories / Accounts / Balances + JSON brut visible.
- B) Upload réel
  - Frontend `VITE_UPLOAD_ENABLED=1`, Backend `ENABLE_UPLOAD=1` `ENABLE_XLSX=1`.
  - Sélection fichier `.xlsx` → POST multipart → 201.
  - GET rapport → rendu identique (cartes + JSON).
- C) Erreurs
  - Fichier non `.xlsx` → message “Un fichier .xlsx est attendu.”
  - Backend down → message “fetch failed …”/erreur réseau affichée.
  - ID inexistant → “Import introuvable …” (message backend).

Closes #5

------
https://chatgpt.com/codex/tasks/task_e_68f0c37d0acc8324ac36c47b3c2901d2