### PR TITLE
Lot 6 — Transactions UI (liste + filtres)

### DIFF
--- a/docs/UAT.md
+++ b/docs/UAT.md
@@ -18,3 +18,11 @@
 
 ## 6. Dashboard
 - KPIs cohÃ©rents, barres annuelles (revenus/dÃ©penses/provisions), courbe solde mensuel ok.
+
+## 7. Transactions (Lot 6)
+- Lancer le frontend Lot 6 : la carte Transactions s'affiche avant l'import.
+- Les listes Comptes et CatÃ©gories sont alimentÃ©es par l'API (tous + libellÃ©s).
+- GET /transactions (limite 50) â‡’ tableau triÃ© par date desc., total affichÃ©.
+- Filtrer par compte â‡’ uniquement les opÃ©rations du compte + total mis Ã  jour.
+- Filtrer par catÃ©gorie â‡’ restreint la liste (0 â‡’ message Aucune transaction).
+- RÃ©initialiser â‡’ retour aux filtres par dÃ©faut et reload auto.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,4 @@
-# Lot 5 – Frontend Import (upload réel + rapport)
+# Lot 6 – Frontend Transactions (liste + filtres)
 
 ## Variables d'environnement
 - `VITE_API_URL` (par défaut `http://localhost:3000`)
@@ -28,11 +28,17 @@ Frontend :
 set VITE_UPLOAD_ENABLED=1 && npm run dev
 
 
-## Flux
+## Flux Import Excel
 1. Créer un import (POST /imports/excel) :
    - avec fichier .xlsx si UI upload active,
    - sinon fallback stub.
 2. Récupérer le rapport (GET /imports/:id) et afficher les cartes + JSON.
+
+## Transactions (Lot 6)
+- Liste des dernières transactions (GET /transactions) avec tri desc.
+- Filtres dynamiques par compte, catégorie et limite.
+- Affiche le nombre de lignes, la somme visible et la catégorisation.
+- Requêtes fetch natives, aucun ajout de dépendance.
 
 ## Notes
 - Aucune dépendance supplémentaire (fetch natif, Tailwind).

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -39,3 +39,34 @@ export async function getImportReport(id) {
   const res = await fetch(`${API_URL}/imports/${encodeURIComponent(id)}`);
   return jsonOrThrow(res, `GET /imports/${id} failed`);
 }
+
+export async function getAccounts() {
+  const res = await fetch(`${API_URL}/accounts`);
+  return jsonOrThrow(res, 'GET /accounts failed');
+}
+
+export async function getCategories(params = {}) {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      search.append(key, value);
+    }
+  });
+  const query = search.toString();
+  const res = await fetch(`${API_URL}/categories${query ? `?${query}` : ''}`);
+  return jsonOrThrow(res, 'GET /categories failed');
+}
+
+export async function getTransactions(params = {}, options = {}) {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      search.append(key, value);
+    }
+  });
+  const query = search.toString();
+  const res = await fetch(`${API_URL}/transactions${query ? `?${query}` : ''}`, {
+    signal: options.signal,
+  });
+  return jsonOrThrow(res, 'GET /transactions failed');
+}


### PR DESCRIPTION
## Summary
- add a transactions card with live filters, totals and Tailwind styling consistent with lot 5
- expose API helpers for accounts, categories and transactions
- document the lot 6 flow in the frontend README and UAT checklist

## Testing
- npm --prefix frontend run build

Closes #6

------
https://chatgpt.com/codex/tasks/task_e_68f1017ba42c83248df7bb0b29cd50eb