### PR TITLE
Lot 9 — Règles de catégorisation (CRUD + import)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,10 @@ Puis, dans `frontend/` :
 ```
 npm run dev
 ```
+
+## Lot 9 — Règles de catégorisation (CRUD + import)
+
+- Appliquer le schéma et le jeu d'essai avec `npm run db:rules` dans `backend/`.
+- L'API Express expose `/rules` (GET/POST/PUT/DELETE) avec tri `priority DESC, created_at ASC` et validations côté serveur.
+- L'import réel charge les règles actives depuis PostgreSQL, normalise les descriptions (minuscules, sans accents) et associe la catégorie lorsque le mot-clé est trouvé.
+- Le frontend dispose d'un onglet **Règles** pour gérer le CRUD (création, édition, suppression, activation) et affiche « DB désactivée » quand `DISABLE_DB=1`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "db:up": "docker compose -f ../docker-compose.dev.yml up -d db",
     "db:schema": "psql \"postgresql://budget:budget@localhost:5432/budget\" -f ./sql/001_schema.sql",
     "db:seed": "psql \"postgresql://budget:budget@localhost:5432/budget\" -f ./sql/002_seed_demo.sql",
+    "db:rules": "psql \"postgresql://budget:budget@localhost:5432/budget\" -f ./sql/003_rules.sql && psql \"postgresql://budget:budget@localhost:5432/budget\" -f ./sql/004_rules_seed.sql",
     "dev": "node --watch ./src/server.js"
   },
   "dependencies": {

--- a/backend/sql/003_rules.sql
+++ b/backend/sql/003_rules.sql
@@ -1,0 +1,11 @@
+BEGIN;
+CREATE TABLE IF NOT EXISTS rule (
+  id SERIAL PRIMARY KEY,
+  target_kind TEXT NOT NULL CHECK (target_kind IN ('income','expense','transfer')),
+  category_id INTEGER NOT NULL REFERENCES category(id),
+  keywords TEXT[] NOT NULL DEFAULT '{}',
+  priority INTEGER NOT NULL DEFAULT 0,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+COMMIT;

--- a/backend/sql/004_rules_seed.sql
+++ b/backend/sql/004_rules_seed.sql
@@ -1,0 +1,8 @@
+BEGIN;
+INSERT INTO rule (target_kind, category_id, keywords, priority, enabled)
+VALUES
+  ('income', 1,  ARRAY['salaire'],                        100, TRUE),
+  ('expense', 4, ARRAY['migros','coop','denner'],          90, TRUE),
+  ('expense', 5, ARRAY['restaurant','café','bar'],         80, TRUE),
+  ('expense', 6, ARRAY['tl','cff','mobility','publibike'], 70, TRUE);
+COMMIT;

--- a/backend/src/routes/imports.js
+++ b/backend/src/routes/imports.js
@@ -451,10 +451,10 @@ router.post('/excel', uploadSingle, async (req, res, next) => {
         const fallbackCategories = buildFallbackCategories(categoryRows);
 
         const { rows: ruleRows } = await client.query(
-          `SELECT r.id, r.target_kind, r.category_id, r.keywords, r.priority
-           FROM rule r
-           WHERE r.enabled = TRUE
-           ORDER BY r.priority DESC, r.created_at ASC`,
+          `SELECT id, target_kind, category_id, keywords, priority
+           FROM rule
+           WHERE enabled = TRUE
+           ORDER BY priority DESC, created_at ASC`,
         );
         const rules = ruleRows.map((rule) => ({
           ...rule,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   getHealth,
   postImportExcelStub,
@@ -7,6 +7,10 @@ import {
   getAccounts,
   getCategories,
   getTransactions,
+  getRules,
+  createRule,
+  updateRule,
+  deleteRule,
 } from './api'
 
 function Badge({ ok }) {
@@ -92,6 +96,371 @@ const categoryKindLabels = {
   transfer: 'Transferts',
 }
 
+function getDefaultRuleForm() {
+  return {
+    target_kind: 'income',
+    category_id: '',
+    keywords: '',
+    priority: '0',
+    enabled: true,
+  }
+}
+
+function RulesTab({ categories }) {
+  const [rules, setRules] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [dbDisabled, setDbDisabled] = useState(false)
+  const [showForm, setShowForm] = useState(false)
+  const [editingRule, setEditingRule] = useState(null)
+  const [form, setForm] = useState(() => getDefaultRuleForm())
+  const [formError, setFormError] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [actionBusy, setActionBusy] = useState(false)
+
+  const categoryMap = useMemo(
+    () => new Map(categories.map(cat => [String(cat.id), cat])),
+    [categories],
+  )
+
+  const loadRules = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const data = await getRules()
+      setRules(Array.isArray(data) ? data : [])
+      setDbDisabled(false)
+    } catch (err) {
+      const message = err?.message || String(err)
+      const disabled = message.toLowerCase().includes('disable_db')
+      setDbDisabled(disabled)
+      setRules([])
+      setError(disabled ? '' : message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadRules()
+  }, [loadRules])
+
+  const availableCategories = useMemo(
+    () => categories.filter(cat => cat.kind === form.target_kind),
+    [categories, form.target_kind],
+  )
+
+  function resetForm() {
+    setForm(getDefaultRuleForm())
+    setEditingRule(null)
+    setFormError('')
+  }
+
+  function handleFormChange(key, value) {
+    if (key === 'target_kind') {
+      setForm(prev => {
+        const matching = categories.some(
+          cat => cat.kind === value && String(cat.id) === prev.category_id,
+        )
+        return {
+          ...prev,
+          target_kind: value,
+          category_id: matching ? prev.category_id : '',
+        }
+      })
+      return
+    }
+    setForm(prev => ({ ...prev, [key]: value }))
+  }
+
+  function handleCreateClick() {
+    resetForm()
+    setShowForm(true)
+  }
+
+  function handleEdit(rule) {
+    setEditingRule(rule)
+    setForm({
+      target_kind: rule.target_kind,
+      category_id: rule.category_id != null ? String(rule.category_id) : '',
+      keywords: Array.isArray(rule.keywords) ? rule.keywords.join(', ') : '',
+      priority: String(rule.priority ?? 0),
+      enabled: rule.enabled !== false,
+    })
+    setFormError('')
+    setShowForm(true)
+  }
+
+  function handleCancelForm() {
+    resetForm()
+    setShowForm(false)
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    setFormError('')
+
+    const categoryId = Number(form.category_id)
+    if (!Number.isInteger(categoryId) || categoryId <= 0) {
+      setFormError('Sélectionnez une catégorie.')
+      return
+    }
+
+    const priorityNumber = Number(form.priority)
+    const priority = Number.isFinite(priorityNumber) ? Math.round(priorityNumber) : 0
+    const keywords = form.keywords
+      .split(/[,\n]/)
+      .map(kw => kw.trim())
+      .filter(Boolean)
+
+    const payload = {
+      target_kind: form.target_kind,
+      category_id: categoryId,
+      keywords,
+      priority,
+      enabled: form.enabled,
+    }
+
+    setSaving(true)
+    try {
+      if (editingRule) {
+        await updateRule(editingRule.id, payload)
+      } else {
+        await createRule(payload)
+      }
+      await loadRules()
+      resetForm()
+      setShowForm(false)
+    } catch (err) {
+      setFormError(err?.message || String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleToggle(rule) {
+    setFormError('')
+    setActionBusy(true)
+    try {
+      await updateRule(rule.id, { enabled: !rule.enabled })
+      await loadRules()
+    } catch (err) {
+      setFormError(err?.message || String(err))
+    } finally {
+      setActionBusy(false)
+    }
+  }
+
+  async function handleDelete(rule) {
+    if (!window.confirm('Supprimer cette règle ?')) return
+    setFormError('')
+    setActionBusy(true)
+    try {
+      await deleteRule(rule.id)
+      await loadRules()
+    } catch (err) {
+      setFormError(err?.message || String(err))
+    } finally {
+      setActionBusy(false)
+    }
+  }
+
+  const tableRows = useMemo(() => {
+    return rules.map(rule => {
+      const category = rule.category_id != null ? categoryMap.get(String(rule.category_id)) : null
+      return [
+        <span className="font-mono" key="id">#{rule.id}</span>,
+        <span className="capitalize" key="kind">{categoryKindLabels[rule.target_kind] || rule.target_kind}</span>,
+        <div className="space-y-0.5" key="category">
+          <div className="font-medium">{category ? category.name : `ID ${rule.category_id}`}</div>
+          <div className="text-xs text-gray-500">{categoryKindLabels[category?.kind] || category?.kind || '—'}</div>
+        </div>,
+        <div className="flex flex-wrap gap-1" key="keywords">
+          {(rule.keywords || []).length
+            ? rule.keywords.map((kw, index) => (
+                <span
+                  key={`${rule.id}-kw-${index}`}
+                  className="px-2 py-0.5 rounded-full bg-gray-100 text-gray-700 text-xs"
+                >
+                  {kw}
+                </span>
+              ))
+            : <span className="text-sm text-gray-500">—</span>}
+        </div>,
+        <span className="font-semibold" key="priority">{rule.priority ?? 0}</span>,
+        <span
+          className={`font-medium ${rule.enabled ? 'text-emerald-600' : 'text-gray-500'}`}
+          key="enabled"
+        >
+          {rule.enabled ? 'Oui' : 'Non'}
+        </span>,
+        <div className="flex flex-wrap gap-2" key="actions">
+          <button
+            type="button"
+            onClick={() => handleEdit(rule)}
+            className="px-2 py-1 rounded border border-gray-300 text-xs hover:bg-gray-100"
+            disabled={saving || actionBusy || dbDisabled}
+          >
+            Éditer
+          </button>
+          <button
+            type="button"
+            onClick={() => handleToggle(rule)}
+            className="px-2 py-1 rounded border border-gray-300 text-xs hover:bg-gray-100"
+            disabled={actionBusy || dbDisabled}
+          >
+            {rule.enabled ? 'Désactiver' : 'Activer'}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleDelete(rule)}
+            className="px-2 py-1 rounded border border-red-300 text-xs text-red-600 hover:bg-red-50"
+            disabled={actionBusy || dbDisabled}
+          >
+            Supprimer
+          </button>
+        </div>,
+      ]
+    })
+  }, [rules, categoryMap, saving, actionBusy, dbDisabled])
+
+  return (
+    <Card
+      title="Règles"
+      right={
+        <div className="flex items-center gap-2 text-xs">
+          <button
+            type="button"
+            onClick={loadRules}
+            className="px-3 py-1 rounded border border-gray-300 hover:bg-gray-100"
+          >
+            Actualiser
+          </button>
+          {loading ? <span className="text-gray-500">Chargement…</span> : null}
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleCreateClick}
+            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+            disabled={dbDisabled}
+          >
+            Créer une règle
+          </button>
+        </div>
+
+        {dbDisabled ? (
+          <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+            DB désactivée
+          </p>
+        ) : null}
+
+        {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+        {showForm ? (
+          <form onSubmit={handleSubmit} className="border rounded p-4 space-y-4 bg-gray-50">
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="text-sm space-y-1">
+                <span className="text-gray-600">Type de cible</span>
+                <select
+                  className="border rounded px-3 py-2"
+                  value={form.target_kind}
+                  onChange={e => handleFormChange('target_kind', e.target.value)}
+                  disabled={saving}
+                >
+                  {Object.entries(categoryKindLabels).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="text-sm space-y-1">
+                <span className="text-gray-600">Catégorie</span>
+                <select
+                  className="border rounded px-3 py-2"
+                  value={form.category_id}
+                  onChange={e => handleFormChange('category_id', e.target.value)}
+                  disabled={saving}
+                >
+                  <option value="">Sélectionner…</option>
+                  {availableCategories.map(cat => (
+                    <option key={cat.id} value={cat.id}>
+                      {cat.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="text-sm space-y-1 md:col-span-2">
+                <span className="text-gray-600">Mots-clés (séparés par des virgules ou retours à la ligne)</span>
+                <textarea
+                  className="border rounded px-3 py-2 h-24"
+                  value={form.keywords}
+                  onChange={e => handleFormChange('keywords', e.target.value)}
+                  placeholder="ex: migros, coop"
+                  disabled={saving}
+                />
+              </label>
+
+              <label className="text-sm space-y-1">
+                <span className="text-gray-600">Priorité</span>
+                <input
+                  type="number"
+                  className="border rounded px-3 py-2"
+                  value={form.priority}
+                  onChange={e => handleFormChange('priority', e.target.value)}
+                  disabled={saving}
+                />
+              </label>
+
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.enabled}
+                  onChange={e => handleFormChange('enabled', e.target.checked)}
+                  disabled={saving}
+                />
+                <span>Activer la règle</span>
+              </label>
+            </div>
+
+            {formError ? <p className="text-sm text-red-600">{formError}</p> : null}
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="submit"
+                className="px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-60"
+                disabled={saving}
+              >
+                {editingRule ? 'Mettre à jour' : 'Créer'}
+              </button>
+              <button
+                type="button"
+                onClick={handleCancelForm}
+                className="px-4 py-2 rounded border border-gray-300 text-gray-700 hover:bg-gray-100"
+                disabled={saving}
+              >
+                Annuler
+              </button>
+            </div>
+          </form>
+        ) : null}
+
+        <Table
+          headers={['ID', 'Cible', 'Catégorie', 'Mots-clés', 'Priorité', 'Active', 'Actions']}
+          rows={tableRows}
+          emptyLabel={loading ? 'Chargement…' : 'Aucune règle'}
+        />
+      </div>
+    </Card>
+  )
+}
+
 export default function App() {
   const [health, setHealth] = useState(null)
   const [importErr, setImportErr] = useState('')
@@ -111,6 +480,7 @@ export default function App() {
   const [transactionsMetaErr, setTransactionsMetaErr] = useState('')
   const [transactionsBusy, setTransactionsBusy] = useState(false)
   const [filters, setFilters] = useState({ accountId: '', categoryId: '', limit: '50' })
+  const [activeTab, setActiveTab] = useState('dashboard')
 
   useEffect(() => {
     getHealth().then(setHealth).catch(e => setImportErr(e.message))
@@ -292,240 +662,274 @@ export default function App() {
       <div className="max-w-5xl mx-auto p-6 space-y-6">
         <h1 className="text-2xl font-bold">Budget — Frontend (Lot 6)</h1>
 
-        <Card title="Santé backend" right={<Badge ok={health?.status === 'ok'} />}>
-          <pre className="text-sm bg-gray-100 p-3 rounded overflow-auto">
-            {JSON.stringify(health, null, 2)}
-          </pre>
-        </Card>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setActiveTab('dashboard')}
+            className={`px-4 py-2 rounded ${
+              activeTab === 'dashboard'
+                ? 'bg-blue-600 text-white'
+                : 'border border-gray-300 text-gray-700 hover:bg-gray-100'
+            }`}
+          >
+            Tableau de bord
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('rules')}
+            className={`px-4 py-2 rounded ${
+              activeTab === 'rules'
+                ? 'bg-blue-600 text-white'
+                : 'border border-gray-300 text-gray-700 hover:bg-gray-100'
+            }`}
+          >
+            Règles
+          </button>
+        </div>
 
-        <Card
-          title="Transactions"
-          right={
-            <span className="text-sm px-2 py-1 rounded bg-amber-50 text-amber-700">
-              Liste temps-réel avec filtres
-            </span>
-          }
-        >
-          <div className="space-y-4">
-            <div className="grid gap-3 md:grid-cols-4">
-              <label className="text-sm space-y-1">
-                <span className="text-gray-600">Compte</span>
-                <select
-                  className="border rounded px-3 py-2 w-full"
-                  value={filters.accountId}
-                  onChange={e => handleFilterChange('accountId', e.target.value)}
-                >
-                  <option value="">Tous</option>
-                  {accountOptions.map(option => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <label className="text-sm space-y-1">
-                <span className="text-gray-600">Catégorie</span>
-                <select
-                  className="border rounded px-3 py-2 w-full"
-                  value={filters.categoryId}
-                  onChange={e => handleFilterChange('categoryId', e.target.value)}
-                >
-                  <option value="">Toutes</option>
-                  {categoryOptions.map(option => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <label className="text-sm space-y-1">
-                <span className="text-gray-600">Limite</span>
-                <input
-                  type="number"
-                  min={1}
-                  className="border rounded px-3 py-2 w-full"
-                  value={filters.limit}
-                  onChange={e => handleFilterChange('limit', e.target.value)}
-                />
-              </label>
-
-              <div className="flex items-end gap-2">
-                <button
-                  type="button"
-                  onClick={handleResetFilters}
-                  className="px-4 py-2 rounded border border-gray-300 text-sm text-gray-700 hover:bg-gray-100"
-                >
-                  Réinitialiser
-                </button>
-                {transactionsBusy ? (
-                  <span className="text-xs text-gray-500">Chargement…</span>
-                ) : null}
-              </div>
-            </div>
-
-            {transactionsMetaErr ? (
-              <p className="text-sm text-red-600">{transactionsMetaErr}</p>
-            ) : null}
-            {transactionsErr ? (
-              <p className="text-sm text-red-600">{transactionsErr}</p>
-            ) : null}
-
-            <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-gray-600">
-              <div>
-                {transactions.length} transaction{transactions.length > 1 ? 's' : ''}
-                {filters.accountId
-                  ? ` · ${accountById[filters.accountId]?.name || filters.accountId}`
-                  : ''}
-                {filters.categoryId
-                  ? ` · ${categoryById[filters.categoryId]?.name || 'Catégorie inconnue'}`
-                  : ''}
-              </div>
-              <div className={`font-semibold ${transactionsTotal < 0 ? 'text-red-600' : 'text-emerald-600'}`}>
-                Total affiché : {formatAmount(transactionsTotal, 'CHF')}
-              </div>
-            </div>
-
-            <Table
-              headers={['Date', 'Description', 'Montant', 'Catégorie & Compte', 'Statut']}
-              rows={transactionsRows}
-              emptyLabel={transactionsBusy ? 'Chargement…' : 'Aucune transaction'}
-            />
-          </div>
-        </Card>
-
-        <Card
-          title="Import Excel"
-          right={<span className="text-sm px-2 py-1 rounded bg-indigo-50 text-indigo-700">
-            {uploadEnabled ? 'Upload réel (si backend ENABLE_UPLOAD/ENABLE_XLSX)' : 'Mode stub (pas de fichier requis)'}
-          </span>}
-        >
-          <div className="grid gap-3 md:grid-cols-[1fr_auto]">
-            <div className="space-y-3">
-              {uploadEnabled && (
-                <input
-                  type="file"
-                  accept=".xlsx"
-                  onChange={e => setFile(e.target.files?.[0] || null)}
-                  className="block w-full text-sm file:mr-3 file:py-2 file:px-3 file:rounded file:border-0 file:bg-blue-600 file:text-white hover:file:bg-blue-700"
-                />
-              )}
-
-              <div className="flex gap-2 flex-wrap">
-                <button
-                  onClick={handleCreateImport}
-                  disabled={busy || (uploadEnabled && !file)}
-                  className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
-                >
-                  Créer un import (POST /imports/excel)
-                </button>
-
-                <input
-                  className="border rounded px-3 py-2 w-48"
-                  placeholder="import_batch_id"
-                  value={batchId}
-                  onChange={e => setBatchId(e.target.value)}
-                />
-
-                <button
-                  onClick={handleFetchReport}
-                  disabled={busy || !batchId}
-                  className="px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50"
-                >
-                  Récupérer le rapport (GET /imports/:id)
-                </button>
-              </div>
-
-              {importErr ? <p className="text-sm text-red-600">Erreur : {importErr}</p> : null}
-
-              {postResp && (
-                <div className="space-y-2">
-                  <h3 className="font-medium">Réponse POST</h3>
-                  <pre className="text-sm bg-gray-100 p-3 rounded overflow-auto">
-                    {JSON.stringify(postResp, null, 2)}
-                  </pre>
-                </div>
-              )}
-            </div>
-
-            {/* Résumé instantané */}
-            <div className="bg-gray-50 rounded p-3 h-max">
-              <div className="font-semibold mb-2">Résumé</div>
-              <KeyVal k="import_batch_id" v={postResp?.import_batch_id} />
-              <KeyVal k="totals.parsed" v={postResp?.report?.totals?.parsed} />
-              <KeyVal k="totals.created" v={postResp?.report?.totals?.created} />
-              <KeyVal k="ignored.total" v={
-                (postResp?.report?.ignored?.duplicates ?? 0) +
-                (postResp?.report?.ignored?.missing_account ?? 0) +
-                (postResp?.report?.ignored?.invalid ?? 0)
-              } />
-            </div>
-          </div>
-        </Card>
-
-        {report && (
-          <Card title="Rapport d'import">
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="bg-gray-50 p-3 rounded">
-                <div className="font-semibold mb-2">Totals</div>
-                <ul className="list-disc ms-5 text-sm">
-                  <li>parsed: {totals.parsed ?? '-'}</li>
-                  <li>created: {totals.created ?? '-'}</li>
-                </ul>
-              </div>
-
-              <div className="bg-gray-50 p-3 rounded">
-                <div className="font-semibold mb-2">Ignored</div>
-                <ul className="list-disc ms-5 text-sm">
-                  <li>duplicates: {ignored.duplicates ?? '-'}</li>
-                  <li>missing_account: {ignored.missing_account ?? '-'}</li>
-                  <li>invalid: {ignored.invalid ?? '-'}</li>
-                </ul>
-              </div>
-
-              <div className="bg-gray-50 p-3 rounded md:col-span-2">
-                <div className="font-semibold mb-2">Categories</div>
-                <Table
-                  headers={['Name', 'Kind', 'Count']}
-                  rows={(categoriesRows || []).sort((a, b) => (b[2] ?? 0) - (a[2] ?? 0))}
-                  emptyLabel="Aucune catégorie"
-                />
-              </div>
-
-              <div className="bg-gray-50 p-3 rounded md:col-span-2">
-                <div className="font-semibold mb-2">Accounts</div>
-                <Table
-                  headers={['Name', 'IBAN', 'Created']}
-                  rows={accountsRows || []}
-                  emptyLabel="Aucun compte"
-                />
-              </div>
-
-              <div className="bg-gray-50 p-3 rounded md:col-span-2">
-                <div className="font-semibold mb-2">Balances</div>
-                <div className="grid md:grid-cols-2 gap-3 text-sm">
-                  <div>
-                    <div className="font-medium mb-1">Expected</div>
-                    <KeyVal k="start" v={balances?.expected?.start} />
-                    <KeyVal k="end" v={balances?.expected?.end} />
-                  </div>
-                  <div>
-                    <div className="font-medium mb-1">Actual</div>
-                    <KeyVal k="start" v={balances?.actual?.start} />
-                    <KeyVal k="end" v={balances?.actual?.end} />
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <details className="mt-3">
-              <summary className="cursor-pointer select-none text-sm text-gray-700">Voir le JSON brut</summary>
-              <pre className="text-xs bg-gray-100 p-3 rounded overflow-auto mt-2">
-                {JSON.stringify(report, null, 2)}
+        {activeTab === 'dashboard' ? (
+          <>
+            <Card title="Santé backend" right={<Badge ok={health?.status === 'ok'} />}>
+              <pre className="text-sm bg-gray-100 p-3 rounded overflow-auto">
+                {JSON.stringify(health, null, 2)}
               </pre>
-            </details>
-          </Card>
+            </Card>
+
+            <Card
+              title="Transactions"
+              right={
+                <span className="text-sm px-2 py-1 rounded bg-amber-50 text-amber-700">
+                  Liste temps-réel avec filtres
+                </span>
+              }
+            >
+              <div className="space-y-4">
+                <div className="grid gap-3 md:grid-cols-4">
+                  <label className="text-sm space-y-1">
+                    <span className="text-gray-600">Compte</span>
+                    <select
+                      className="border rounded px-3 py-2 w-full"
+                      value={filters.accountId}
+                      onChange={e => handleFilterChange('accountId', e.target.value)}
+                    >
+                      <option value="">Tous</option>
+                      {accountOptions.map(option => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="text-sm space-y-1">
+                    <span className="text-gray-600">Catégorie</span>
+                    <select
+                      className="border rounded px-3 py-2 w-full"
+                      value={filters.categoryId}
+                      onChange={e => handleFilterChange('categoryId', e.target.value)}
+                    >
+                      <option value="">Toutes</option>
+                      {categoryOptions.map(option => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="text-sm space-y-1">
+                    <span className="text-gray-600">Limite</span>
+                    <input
+                      type="number"
+                      min={1}
+                      className="border rounded px-3 py-2 w-full"
+                      value={filters.limit}
+                      onChange={e => handleFilterChange('limit', e.target.value)}
+                    />
+                  </label>
+
+                  <div className="flex items-end gap-2">
+                    <button
+                      type="button"
+                      onClick={handleResetFilters}
+                      className="px-4 py-2 rounded border border-gray-300 text-sm text-gray-700 hover:bg-gray-100"
+                    >
+                      Réinitialiser
+                    </button>
+                    {transactionsBusy ? (
+                      <span className="text-xs text-gray-500">Chargement…</span>
+                    ) : null}
+                  </div>
+                </div>
+
+                {transactionsMetaErr ? (
+                  <p className="text-sm text-red-600">{transactionsMetaErr}</p>
+                ) : null}
+                {transactionsErr ? (
+                  <p className="text-sm text-red-600">{transactionsErr}</p>
+                ) : null}
+
+                <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-gray-600">
+                  <div>
+                    {transactions.length} transaction{transactions.length > 1 ? 's' : ''}
+                    {filters.accountId
+                      ? ` · ${accountById[filters.accountId]?.name || filters.accountId}`
+                      : ''}
+                    {filters.categoryId
+                      ? ` · ${categoryById[filters.categoryId]?.name || 'Catégorie inconnue'}`
+                      : ''}
+                  </div>
+                  <div className={`font-semibold ${transactionsTotal < 0 ? 'text-red-600' : 'text-emerald-600'}`}>
+                    Total affiché : {formatAmount(transactionsTotal, 'CHF')}
+                  </div>
+                </div>
+
+                <Table
+                  headers={['Date', 'Description', 'Montant', 'Catégorie & Compte', 'Statut']}
+                  rows={transactionsRows}
+                  emptyLabel={transactionsBusy ? 'Chargement…' : 'Aucune transaction'}
+                />
+              </div>
+            </Card>
+
+            <Card
+              title="Import Excel"
+              right={<span className="text-sm px-2 py-1 rounded bg-indigo-50 text-indigo-700">
+                {uploadEnabled ? 'Upload réel (si backend ENABLE_UPLOAD/ENABLE_XLSX)' : 'Mode stub (pas de fichier requis)'}
+              </span>}
+            >
+              <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+                <div className="space-y-3">
+                  {uploadEnabled && (
+                    <input
+                      type="file"
+                      accept=".xlsx"
+                      onChange={e => setFile(e.target.files?.[0] || null)}
+                      className="block w-full text-sm file:mr-3 file:py-2 file:px-3 file:rounded file:border-0 file:bg-blue-600 file:text-white hover:file:bg-blue-700"
+                    />
+                  )}
+
+                  <div className="flex gap-2 flex-wrap">
+                    <button
+                      onClick={handleCreateImport}
+                      disabled={busy || (uploadEnabled && !file)}
+                      className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      Créer un import (POST /imports/excel)
+                    </button>
+
+                    <input
+                      className="border rounded px-3 py-2 w-48"
+                      placeholder="import_batch_id"
+                      value={batchId}
+                      onChange={e => setBatchId(e.target.value)}
+                    />
+
+                    <button
+                      onClick={handleFetchReport}
+                      disabled={busy || !batchId}
+                      className="px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50"
+                    >
+                      Récupérer le rapport (GET /imports/:id)
+                    </button>
+                  </div>
+
+                  {importErr ? <p className="text-sm text-red-600">Erreur : {importErr}</p> : null}
+
+                  {postResp && (
+                    <div className="space-y-2">
+                      <h3 className="font-medium">Réponse POST</h3>
+                      <pre className="text-sm bg-gray-100 p-3 rounded overflow-auto">
+                        {JSON.stringify(postResp, null, 2)}
+                      </pre>
+                    </div>
+                  )}
+                </div>
+
+                {/* Résumé instantané */}
+                <div className="bg-gray-50 rounded p-3 h-max">
+                  <div className="font-semibold mb-2">Résumé</div>
+                  <KeyVal k="import_batch_id" v={postResp?.import_batch_id} />
+                  <KeyVal k="totals.parsed" v={postResp?.report?.totals?.parsed} />
+                  <KeyVal k="totals.created" v={postResp?.report?.totals?.created} />
+                  <KeyVal
+                    k="ignored.total"
+                    v={
+                      (postResp?.report?.ignored?.duplicates ?? 0) +
+                      (postResp?.report?.ignored?.missing_account ?? 0) +
+                      (postResp?.report?.ignored?.invalid ?? 0)
+                    }
+                  />
+                </div>
+              </div>
+            </Card>
+
+            {report && (
+              <Card title="Rapport d'import">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="bg-gray-50 p-3 rounded">
+                    <div className="font-semibold mb-2">Totals</div>
+                    <ul className="list-disc ms-5 text-sm">
+                      <li>parsed: {totals.parsed ?? '-'}</li>
+                      <li>created: {totals.created ?? '-'}</li>
+                    </ul>
+                  </div>
+
+                  <div className="bg-gray-50 p-3 rounded">
+                    <div className="font-semibold mb-2">Ignored</div>
+                    <ul className="list-disc ms-5 text-sm">
+                      <li>duplicates: {ignored.duplicates ?? '-'}</li>
+                      <li>missing_account: {ignored.missing_account ?? '-'}</li>
+                      <li>invalid: {ignored.invalid ?? '-'}</li>
+                    </ul>
+                  </div>
+
+                  <div className="bg-gray-50 p-3 rounded md:col-span-2">
+                    <div className="font-semibold mb-2">Categories</div>
+                    <Table
+                      headers={['Name', 'Kind', 'Count']}
+                      rows={(categoriesRows || []).sort((a, b) => (b[2] ?? 0) - (a[2] ?? 0))}
+                      emptyLabel="Aucune catégorie"
+                    />
+                  </div>
+
+                  <div className="bg-gray-50 p-3 rounded md:col-span-2">
+                    <div className="font-semibold mb-2">Accounts</div>
+                    <Table
+                      headers={['Name', 'IBAN', 'Created']}
+                      rows={accountsRows || []}
+                      emptyLabel="Aucun compte"
+                    />
+                  </div>
+
+                  <div className="bg-gray-50 p-3 rounded md:col-span-2">
+                    <div className="font-semibold mb-2">Balances</div>
+                    <div className="grid md:grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <div className="font-medium mb-1">Expected</div>
+                        <KeyVal k="start" v={balances?.expected?.start} />
+                        <KeyVal k="end" v={balances?.expected?.end} />
+                      </div>
+                      <div>
+                        <div className="font-medium mb-1">Actual</div>
+                        <KeyVal k="start" v={balances?.actual?.start} />
+                        <KeyVal k="end" v={balances?.actual?.end} />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <details className="mt-3">
+                  <summary className="cursor-pointer select-none text-sm text-gray-700">Voir le JSON brut</summary>
+                  <pre className="text-xs bg-gray-100 p-3 rounded overflow-auto mt-2">
+                    {JSON.stringify(report, null, 2)}
+                  </pre>
+                </details>
+              </Card>
+            )}
+          </>
+        ) : (
+          <RulesTab categories={categories} />
         )}
       </div>
     </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -70,3 +70,44 @@ export async function getTransactions(params = {}, options = {}) {
   });
   return jsonOrThrow(res, 'GET /transactions failed');
 }
+
+export async function getRules() {
+  const res = await fetch(`${API_URL}/rules`);
+  return jsonOrThrow(res, 'GET /rules failed');
+}
+
+export async function createRule(payload) {
+  const res = await fetch(`${API_URL}/rules`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return jsonOrThrow(res, 'POST /rules failed');
+}
+
+export async function updateRule(id, payload) {
+  const res = await fetch(`${API_URL}/rules/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return jsonOrThrow(res, `PUT /rules/${id} failed`);
+}
+
+export async function deleteRule(id) {
+  const res = await fetch(`${API_URL}/rules/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    let data = null;
+    try {
+      data = await res.json();
+    } catch (error) {
+      // ignore body parse errors
+    }
+    const msg =
+      (data && (data.error || data.message)) ||
+      `DELETE /rules/${id} failed: ${res.status} ${res.statusText}`;
+    throw new Error(msg);
+  }
+}


### PR DESCRIPTION
## Objectifs
- Ajouter le schéma SQL et le jeu de données initial pour les règles de catégorisation.
- Étendre le backend Express afin d’exposer le CRUD `/rules` et d’appliquer les règles lors des imports.
- Proposer un onglet frontend pour gérer les règles (création, édition, suppression, activation) et informer lorsque la DB est désactivée.

## Captures
- N/A (interface non lancée dans cet environnement CLI)

## UAT
- [ ] `npm run db:rules`
- [ ] GET /rules non vide
- [ ] Import réel (ENABLE_UPLOAD=1, ENABLE_XLSX=1, DISABLE_DB=0) → catégorisation visible dans le rapport
- [ ] Désactivation d’une règle → ré-import = plus de catégorisation correspondante
- [ ] Mode stub : page Règles affiche « DB désactivée » (à vérifier manuellement)

Closes #9.

------
https://chatgpt.com/codex/tasks/task_e_68f23f31ad248324b46464e7146dbf35