### PR TITLE
Fix import batch insert parameters and add logging

### DIFF
--- a/backend/src/routes/imports.js
+++ b/backend/src/routes/imports.js
@@ -472,7 +472,7 @@ router.post('/excel', uploadSingle, async (req, res, next) => {
         `INSERT INTO import_batch (source, original_filename, hash, status)
          VALUES ($1, $2, $3, $4)
          RETURNING *`,
-        ['excel', req.file?.originalname ?? 'stub.json', fileHash ?? 'stub'],
+        ['excel', req.file?.originalname ?? 'stub.json', fileHash ?? 'stub', 'pending'],
       );
       const importBatch = createdAt.rows[0];
 
@@ -609,6 +609,12 @@ router.post('/excel', uploadSingle, async (req, res, next) => {
           );
 
           const transaction = inserted.rows[0];
+          console.log('✅ Transaction inserted', {
+            accountId: account.id,
+            occurred_on: row.occurred_on,
+            amount: row.amount,
+            description: row.description,
+          });
           createdTransactions.push(transaction);
           seenHashes.add(hash);
           accountHashes.add(hash);


### PR DESCRIPTION
## Summary
- provide the missing status parameter when creating an import batch record
- add a console log to confirm each transaction inserted during imports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901f3e26d348324a873d84d53eada80