### PR TITLE
Fix Excel upload handling and CORS configuration

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -18,7 +18,7 @@ import healthRouter from './routes/health.js';
 export function createApp() {
   const app = express();
 
-  app.use(cors());
+  app.use(cors({ origin: 'http://localhost:5173' }));
   app.use(express.json());
   app.use(morgan('dev'));
 


### PR DESCRIPTION
## Summary
- write uploaded Excel files to a persistent uploads directory before parsing and hashing
- ensure temporary files are cleaned up and stub mode continues to work without a database
- allow the Vite frontend origin in the backend CORS policy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69022392a60c83248560f4b50b040167