### PR TITLE
Fix GET /imports/:id response handling

### DIFF
--- a/backend/src/routes/imports.js
+++ b/backend/src/routes/imports.js
@@ -832,7 +832,7 @@ router.get('/:id', async (req, res, next) => {
     const rawReport = parsedMessage?.report ?? parsedMessage;
     const report = normalizeReport(rawReport);
 
-    res.json({
+    return res.json({
       import_batch_id: batch.id,
       report,
     });


### PR DESCRIPTION
## Summary
- ensure the GET /imports/:id handler returns immediately after sending the normalized report response

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69032eed1fb4832484d0a41a6450efc9