### PR TITLE
feat: implement global imports summary report

### DIFF
--- a/backend/src/routes/imports.js
+++ b/backend/src/routes/imports.js
@@ -812,6 +812,112 @@ function normalizeReport(rawReport) {
   };
 }
 
+router.get('/summary', async (req, res, next) => {
+  try {
+    if (DISABLE_DB) {
+      return res.json({
+        summary: {
+          imports_count: 0,
+          transactions_total: 0,
+          transactions_created: 0,
+          transactions_ignored: 0,
+          accounts: [],
+          categories: [],
+          balances: { actual: { start: null, end: null } },
+        },
+      });
+    }
+
+    const client = await pool.connect();
+    try {
+      const { rows: importStatsRows } = await client.query(
+        `SELECT COUNT(*)::bigint AS imports_count, COALESCE(SUM(rows_count), 0)::bigint AS transactions_total
+           FROM import_batch`,
+      );
+      const importsCount = Number(importStatsRows[0]?.imports_count ?? 0);
+      const transactionsTotal = Number(importStatsRows[0]?.transactions_total ?? 0);
+
+      const { rows: transactionsCreatedRows } = await client.query(
+        `SELECT COUNT(*)::bigint AS transactions_created FROM transaction`,
+      );
+      const transactionsCreated = Number(transactionsCreatedRows[0]?.transactions_created ?? 0);
+
+      const transactionsIgnored = Math.max(transactionsTotal - transactionsCreated, 0);
+
+      const { rows: accountRows } = await client.query(
+        `SELECT a.id, a.name, a.iban, COUNT(t.id)::bigint AS created
+           FROM transaction t
+           JOIN account a ON a.id = t.account_id
+          GROUP BY a.id, a.name, a.iban
+          ORDER BY a.name ASC, a.id ASC`,
+      );
+      const accounts = accountRows.map((row) => {
+        const id = Number(row.id);
+        return {
+          id: Number.isFinite(id) ? id : null,
+          name: row.name ?? '',
+          iban: row.iban ?? null,
+          created: Number(row.created ?? 0),
+        };
+      });
+
+      const { rows: categoryRows } = await client.query(
+        `SELECT c.id, c.name, c.kind, COUNT(t.id)::bigint AS count
+           FROM transaction t
+           JOIN category c ON c.id = t.category_id
+          GROUP BY c.id, c.name, c.kind
+          ORDER BY COUNT(t.id) DESC, c.name ASC, c.id ASC`,
+      );
+      const categories = categoryRows.map((row) => {
+        const id = Number(row.id);
+        return {
+          id: Number.isFinite(id) ? id : null,
+          name: row.name ?? '',
+          kind: row.kind ?? null,
+          count: Number(row.count ?? 0),
+        };
+      });
+
+      const { rows: sumAmountRows } = await client.query(
+        `SELECT COALESCE(SUM(amount), 0) AS total_amount FROM transaction`,
+      );
+      const netAmountRaw = sumAmountRows[0]?.total_amount;
+      const netAmount = Number(netAmountRaw);
+
+      const { rows: balanceRows } = await client.query(
+        `SELECT balance_after
+           FROM transaction
+          WHERE balance_after IS NOT NULL
+          ORDER BY occurred_on DESC NULLS LAST, id DESC
+          LIMIT 1`,
+      );
+      const actualEndRaw = balanceRows[0]?.balance_after;
+      const actualEnd = Number.isFinite(Number(actualEndRaw)) ? Number(actualEndRaw) : null;
+
+      let actualStart = null;
+      if (actualEnd !== null && Number.isFinite(netAmount)) {
+        actualStart = Number((actualEnd - netAmount).toFixed(2));
+      }
+
+      const summary = {
+        imports_count: importsCount,
+        transactions_total: transactionsTotal,
+        transactions_created: transactionsCreated,
+        transactions_ignored: transactionsIgnored,
+        accounts,
+        categories,
+        balances: { actual: { start: actualStart, end: actualEnd } },
+      };
+
+      return res.json({ summary });
+    } finally {
+      client.release();
+    }
+  } catch (error) {
+    next(error);
+  }
+});
+
 router.get('/:id', async (req, res, next) => {
   try {
     if (DISABLE_DB) {


### PR DESCRIPTION
## Summary
- add a new `/imports/summary` route that aggregates import, transaction, account, and category metrics
- compute account and category breakdowns plus derived balance information for the global imports summary
- ensure the route returns an empty structured response when the database is disabled

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69033dd01f9083248a1fb889a742f06b