### PR TITLE
Implement export of global summary as Excel file (Lot 11)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
+    "exceljs": "^4.4.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "morgan": "^1.10.0",

--- a/frontend/src/views/GlobalReportView.jsx
+++ b/frontend/src/views/GlobalReportView.jsx
@@ -89,7 +89,18 @@ export default function GlobalReportView() {
 
   return (
     <div className="space-y-6">
-      <Card title="Résumé global des imports">
+      <Card
+        title="Résumé global des imports"
+        right={(
+          <button
+            type="button"
+            onClick={() => window.open('http://localhost:3000/imports/summary/export', '_blank')}
+            className="px-3 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+          >
+            Exporter (.xlsx)
+          </button>
+        )}
+      >
         {loading ? (
           <p className="text-sm text-gray-600">Chargement du résumé...</p>
         ) : error ? (


### PR DESCRIPTION
## Summary
- add exceljs dependency and reuse the summary computation for both JSON and export responses
- add a GET /imports/summary/export route that builds the Excel workbook for the global import report
- expose an Exporter (.xlsx) action in the global report view to trigger the download

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903492e4a4083248d57c1eb975808a0