### PR TITLE
Fix owner_person_id handling in AccountsView

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -24,7 +24,21 @@ function serializeAccountPayload(payload, { forUpdate = false } = {}) {
   }
 
   if ('owner_person_id' in payload) {
-    body.owner_person_id = payload.owner_person_id;
+    const rawOwnerId = payload.owner_person_id;
+    if (rawOwnerId !== '' && rawOwnerId !== null && rawOwnerId !== undefined) {
+      if (typeof rawOwnerId === 'number') {
+        body.owner_person_id = rawOwnerId;
+      } else if (typeof rawOwnerId === 'string') {
+        const trimmed = rawOwnerId.trim();
+        if (trimmed && /^-?\d+$/.test(trimmed)) {
+          body.owner_person_id = Number(trimmed);
+        } else if (trimmed) {
+          body.owner_person_id = trimmed;
+        }
+      } else {
+        body.owner_person_id = rawOwnerId;
+      }
+    }
   }
 
   return body;

--- a/frontend/src/views/AccountsView.jsx
+++ b/frontend/src/views/AccountsView.jsx
@@ -108,9 +108,11 @@ function AccountForm({ initialAccount, onSubmit, onCancel, submitting }) {
 
     const ownerId = form.owner_person_id.trim()
     if (ownerId) {
-      payload.owner_person_id = ownerId
-    } else {
-      payload.owner_person_id = null
+      if (/^-?\d+$/.test(ownerId)) {
+        payload.owner_person_id = Number(ownerId)
+      } else {
+        payload.owner_person_id = ownerId
+      }
     }
 
     try {
@@ -177,7 +179,6 @@ function AccountForm({ initialAccount, onSubmit, onCancel, submitting }) {
             value={form.owner_person_id}
             onChange={event => updateField('owner_person_id', event.target.value)}
             className="border rounded px-3 py-2"
-            placeholder="p1"
           />
         </label>
       </div>


### PR DESCRIPTION
## Summary
- sanitize the AccountsView form to omit empty owner_person_id values and convert numeric entries to numbers
- mirror the new owner_person_id handling in the API serializer to avoid sending empty strings
- remove the default placeholder from the owner field

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690363c9bdc4832493eefc86cdb58a80