### PR TITLE
Create person table migration and run migrations on startup

### DIFF
--- a/backend/scripts/run-migrations.js
+++ b/backend/scripts/run-migrations.js
@@ -1,8 +1,7 @@
 import { config } from 'dotenv';
-import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { Client } from 'pg';
+import { runMigrations } from '../src/db/migrations.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,83 +9,10 @@ const __dirname = path.dirname(__filename);
 config({ path: path.join(__dirname, '..', '.env') });
 config();
 
-const databaseUrl = process.env.DATABASE_URL;
-if (!databaseUrl) {
-  console.error('DATABASE_URL is not defined. Please configure backend/.env (see backend/.env.example).');
-  process.exit(1);
-}
-
 const reset = process.argv.includes('--reset');
-const migrationsDir = path.join(__dirname, '..', 'migrations');
 
-async function ensureMigrationsTable(client) {
-  await client.query(`
-    CREATE TABLE IF NOT EXISTS schema_migrations (
-      name TEXT PRIMARY KEY,
-      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-    )
-  `);
-}
-
-async function appliedMigrations(client) {
-  const { rows } = await client.query('SELECT name FROM schema_migrations');
-  return new Set(rows.map((row) => row.name));
-}
-
-async function applyMigration(client, filePath, name) {
-  const sql = await fs.readFile(filePath, 'utf8');
-  console.log(`→ Applying migration ${name}`);
-  await client.query('BEGIN');
-  try {
-    await client.query(sql);
-    await client.query('INSERT INTO schema_migrations (name) VALUES ($1)', [name]);
-    await client.query('COMMIT');
-  } catch (error) {
-    await client.query('ROLLBACK');
-    console.error(`⚠️  Failed to apply migration ${name}`);
-    throw error;
-  }
-}
-
-async function main() {
-  const client = new Client({ connectionString: databaseUrl });
-
-  try {
-    await client.connect();
-
-    if (reset) {
-      console.log('Resetting public schema…');
-      await client.query('DROP SCHEMA IF EXISTS public CASCADE');
-      await client.query('CREATE SCHEMA IF NOT EXISTS public');
-      await client.query('GRANT USAGE ON SCHEMA public TO public');
-      await client.query('GRANT CREATE ON SCHEMA public TO public');
-    }
-
-    await ensureMigrationsTable(client);
-
-    const files = (await fs.readdir(migrationsDir))
-      .filter((file) => file.endsWith('.sql'))
-      .sort();
-
-    const alreadyApplied = await appliedMigrations(client);
-
-    for (const file of files) {
-      if (alreadyApplied.has(file)) {
-        console.log(`✓ Skipping already applied migration ${file}`);
-        continue;
-      }
-
-      const filePath = path.join(migrationsDir, file);
-      await applyMigration(client, filePath, file);
-    }
-
-    console.log('All migrations applied.');
-  } finally {
-    await client.end();
-  }
-}
-
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+runMigrations({ reset })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/backend/src/db/migrations.js
+++ b/backend/src/db/migrations.js
@@ -1,0 +1,146 @@
+import { config } from 'dotenv';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client } from 'pg';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+config({ path: path.join(__dirname, '..', '.env') });
+config();
+
+const migrationsDirectories = [
+  path.join(__dirname, '..', '..', 'migrations'),
+  path.join(__dirname, 'migrations'),
+];
+
+function getClientConfig() {
+  if (process.env.DATABASE_URL) {
+    const ssl = process.env.DATABASE_SSL === '1' ? { rejectUnauthorized: false } : undefined;
+    return { connectionString: process.env.DATABASE_URL, ssl };
+  }
+
+  const requiredVars = ['PGHOST', 'PGPORT', 'PGDATABASE', 'PGUSER', 'PGPASSWORD'];
+  const missing = requiredVars.filter((name) => !process.env[name]);
+  if (missing.length) {
+    throw new Error(
+      `Missing database configuration. Please configure backend/.env (missing: ${missing.join(', ')}).`,
+    );
+  }
+
+  const port = Number(process.env.PGPORT);
+  if (!Number.isFinite(port)) {
+    throw new Error('Invalid database configuration. PGPORT must be a number.');
+  }
+
+  const ssl = process.env.PGSSL === '1' ? { rejectUnauthorized: false } : undefined;
+
+  return {
+    host: process.env.PGHOST,
+    port,
+    database: process.env.PGDATABASE,
+    user: process.env.PGUSER,
+    password: process.env.PGPASSWORD,
+    ssl,
+  };
+}
+
+async function ensureMigrationsTable(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      name TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+}
+
+async function appliedMigrations(client) {
+  const { rows } = await client.query('SELECT name FROM schema_migrations');
+  return new Set(rows.map((row) => row.name));
+}
+
+async function readMigrationFiles() {
+  const migrations = new Map();
+
+  for (const directory of migrationsDirectories) {
+    try {
+      const files = await fs.readdir(directory);
+      for (const file of files) {
+        if (!file.endsWith('.sql')) {
+          continue;
+        }
+
+        if (!migrations.has(file)) {
+          migrations.set(file, path.join(directory, file));
+        }
+      }
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  return Array.from(migrations.entries())
+    .map(([name, filePath]) => ({ name, filePath }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function applyMigration(client, migration, logger) {
+  const sql = await fs.readFile(migration.filePath, 'utf8');
+  logger.log(`→ Applying migration ${migration.name}`);
+  await client.query('BEGIN');
+  try {
+    await client.query(sql);
+    await client.query('INSERT INTO schema_migrations (name) VALUES ($1)', [migration.name]);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    logger.error(`⚠️  Failed to apply migration ${migration.name}`);
+    throw error;
+  }
+}
+
+async function resetSchema(client, logger) {
+  logger.log('Resetting public schema…');
+  await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+  await client.query('CREATE SCHEMA IF NOT EXISTS public');
+  await client.query('GRANT USAGE ON SCHEMA public TO public');
+  await client.query('GRANT CREATE ON SCHEMA public TO public');
+}
+
+export async function runMigrations({ reset = false, logger = console } = {}) {
+  if (process.env.DISABLE_DB === '1') {
+    logger.log('Skipping migrations because DISABLE_DB=1');
+    return;
+  }
+
+  const client = new Client(getClientConfig());
+
+  try {
+    await client.connect();
+
+    if (reset) {
+      await resetSchema(client, logger);
+    }
+
+    await ensureMigrationsTable(client);
+
+    const migrations = await readMigrationFiles();
+    const alreadyApplied = await appliedMigrations(client);
+
+    for (const migration of migrations) {
+      if (alreadyApplied.has(migration.name)) {
+        logger.log(`✓ Skipping already applied migration ${migration.name}`);
+        continue;
+      }
+
+      await applyMigration(client, migration, logger);
+    }
+
+    logger.log('All migrations applied.');
+  } finally {
+    await client.end();
+  }
+}

--- a/backend/src/db/migrations/20251030_add_person_table.sql
+++ b/backend/src/db/migrations/20251030_add_person_table.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+-- 1️⃣ Create person table
+CREATE TABLE IF NOT EXISTS person (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT UNIQUE,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- 2️⃣ Convert account.owner_person_id to integer and link
+ALTER TABLE account
+  ALTER COLUMN owner_person_id TYPE INTEGER USING NULLIF(owner_person_id, '')::INTEGER,
+  ADD CONSTRAINT account_owner_person_fk
+  FOREIGN KEY (owner_person_id) REFERENCES person(id)
+  ON DELETE SET NULL;
+
+COMMIT;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -7,19 +7,29 @@ dotenv.config();
 // ==============================================
 // 🚀 Lancement de l'application Budget API
 // ==============================================
+import { runMigrations } from './db/migrations.js';
 import { createApp } from './app.js';
 
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
-const app = createApp();
 
-// 🔍 Affiche les variables importantes au démarrage
-console.log('==========================================');
-console.log('🌍 Budget API Environment:');
-console.log('ENABLE_UPLOAD =', process.env.ENABLE_UPLOAD);
-console.log('ENABLE_XLSX   =', process.env.ENABLE_XLSX);
-console.log('DISABLE_DB    =', process.env.DISABLE_DB);
-console.log('==========================================');
+async function start() {
+  console.log('==========================================');
+  console.log('🌍 Budget API Environment:');
+  console.log('ENABLE_UPLOAD =', process.env.ENABLE_UPLOAD);
+  console.log('ENABLE_XLSX   =', process.env.ENABLE_XLSX);
+  console.log('DISABLE_DB    =', process.env.DISABLE_DB);
+  console.log('==========================================');
 
-app.listen(port, () => {
-  console.log(`✅ Budget API listening on port ${port}`);
+  await runMigrations();
+
+  const app = createApp();
+  app.listen(port, () => {
+    console.log(`✅ Budget API listening on port ${port}`);
+  });
+}
+
+start().catch((error) => {
+  console.error('❌ Failed to start Budget API');
+  console.error(error);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- add SQL migration to create the person table and link accounts
- introduce a shared migration runner used at startup and from the CLI script
- run migrations automatically when the API boots

## Testing
- DISABLE_DB=1 node backend/scripts/run-migrations.js

------
https://chatgpt.com/codex/tasks/task_e_69037a0d10248324bcbd43b2b2c8294e