### PR TITLE
Implement export of global summary as Excel file (Lot 11)

### DIFF
--- a/backend/src/routes/imports.js
+++ b/backend/src/routes/imports.js
@@ -922,6 +922,10 @@ router.get('/summary', async (req, res, next) => {
 
 router.get('/summary/export', async (req, res, next) => {
   try {
+    if (!ENABLE_XLSX) {
+      throw new HttpError(503, "Export XLSX désactivé.");
+    }
+
     const data = await getGlobalImportSummary();
 
     const workbook = new ExcelJS.Workbook();

--- a/frontend/src/views/GlobalReportView.jsx
+++ b/frontend/src/views/GlobalReportView.jsx
@@ -20,6 +20,10 @@ export default function GlobalReportView() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
+  const handleExport = () => {
+    window.open('/imports/summary/export', '_blank', 'noopener')
+  }
+
   useEffect(() => {
     let active = true
 
@@ -94,7 +98,7 @@ export default function GlobalReportView() {
         right={(
           <button
             type="button"
-            onClick={() => window.open('http://localhost:3000/imports/summary/export', '_blank')}
+            onClick={handleExport}
             className="px-3 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
           >
             Exporter (.xlsx)


### PR DESCRIPTION
## Summary
- guard the XLSX export endpoint when the feature flag is disabled
- expose the global summary export through the UI button that opens the download in a new tab

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69046b3ec1e083248524b34c0999a0a6