### PR TITLE
Handle missing import batch timestamp column

### DIFF
--- a/backend/src/routes/imports.js
+++ b/backend/src/routes/imports.js
@@ -879,7 +879,7 @@ async function getGlobalImportSummary() {
     const { rows: importDetailRows } = await client.query(
       `SELECT ib.id,
               ib.original_filename AS filename,
-              ib.imported_at AS created_at,
+              COALESCE(ib.imported_at, ib.created_at) AS created_at,
               ib.rows_count AS total_transactions,
               COALESCE(stats.created_transactions, 0)::bigint AS created_transactions,
               GREATEST(ib.rows_count - COALESCE(stats.created_transactions, 0), 0)::bigint AS ignored_transactions,


### PR DESCRIPTION
## Summary
- use COALESCE to select imported_at or created_at for import batch timestamps in the export query

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904b138f50c8324907c58fbac40f74d