### PR TITLE
Fix import summary export ordering fallback

### DIFF
--- a/backend/src/routes/imports.js
+++ b/backend/src/routes/imports.js
@@ -893,7 +893,7 @@ async function getGlobalImportSummary() {
                  GROUP BY import_batch_id
               ) AS stats
            ON stats.import_batch_id = ib.id
-        ORDER BY ib.imported_at DESC NULLS LAST, ib.id DESC`,
+        ORDER BY COALESCE(ib.imported_at, ib.created_at) DESC NULLS LAST, ib.id DESC`,
     );
     const importDetails = importDetailRows.map((row) => {
       const id = Number(row.id);


### PR DESCRIPTION
## Summary
- update the imports summary export query to order by the same coalesced timestamp used in the select list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6904b42282c48324b17de72c44fac7e2