### PR TITLE
Filter import errors display to failed imports only (Lot 12B)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -246,7 +246,9 @@ function ImportsDashboard() {
     if (!summary || !Array.isArray(summary.import_errors)) {
       return []
     }
-    return summary.import_errors
+    return summary.import_errors.filter(
+      err => err.status === 'error' || (typeof err.message === 'object' && err.message?.error)
+    )
   }, [importSummary])
 
   const transactionsRows = useMemo(() => {


### PR DESCRIPTION
## Summary
- filter the import errors list to only include failed batches or messages containing an explicit error field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904c516da108324ae998a1d4e0134a7