### PR TITLE
Fix frontend router to restore /imports route

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,12 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-<<<<<<< HEAD
-        "react-dom": "^18.2.0"
-=======
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3"
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.0",
@@ -26,11 +22,8 @@
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -42,11 +35,8 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -59,13 +49,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-<<<<<<< HEAD
-      "version": "7.28.4",
-=======
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
       "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -73,27 +59,13 @@
       }
     },
     "node_modules/@babel/core": {
-<<<<<<< HEAD
-      "version": "7.28.4",
-=======
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-<<<<<<< HEAD
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.4",
-        "@babel/types": "^7.28.4",
-=======
         "@babel/generator": "^7.28.5",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-module-transforms": "^7.28.3",
@@ -102,7 +74,6 @@
         "@babel/template": "^7.27.2",
         "@babel/traverse": "^7.28.5",
         "@babel/types": "^7.28.5",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -119,14 +90,6 @@
       }
     },
     "node_modules/@babel/generator": {
-<<<<<<< HEAD
-      "version": "7.28.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
-=======
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
       "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
@@ -135,7 +98,6 @@
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@babel/types": "^7.28.5",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -146,11 +108,8 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.27.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -166,11 +125,8 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -179,11 +135,8 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.27.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -196,11 +149,8 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -217,11 +167,8 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.27.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
       "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -230,11 +177,8 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -242,13 +186,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-<<<<<<< HEAD
-      "version": "7.27.1",
-=======
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -257,11 +197,8 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -270,11 +207,8 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.28.4",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -286,13 +220,6 @@
       }
     },
     "node_modules/@babel/parser": {
-<<<<<<< HEAD
-      "version": "7.28.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.4"
-=======
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
@@ -300,7 +227,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.5"
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -311,11 +237,8 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.27.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
       "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -330,11 +253,8 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.27.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
       "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -349,11 +269,8 @@
     },
     "node_modules/@babel/template": {
       "version": "7.27.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -366,30 +283,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-<<<<<<< HEAD
-      "version": "7.28.4",
-=======
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
       "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-<<<<<<< HEAD
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
-=======
         "@babel/generator": "^7.28.5",
         "@babel/helper-globals": "^7.28.0",
         "@babel/parser": "^7.28.5",
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.5",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
         "debug": "^4.3.1"
       },
       "engines": {
@@ -397,31 +302,19 @@
       }
     },
     "node_modules/@babel/types": {
-<<<<<<< HEAD
-      "version": "7.28.4",
-=======
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-<<<<<<< HEAD
-        "@babel/helper-validator-identifier": "^7.27.1"
-=======
         "@babel/helper-validator-identifier": "^7.28.5"
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-=======
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -800,7 +693,6 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
       "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "cpu": [
         "x64"
       ],
@@ -816,11 +708,8 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -837,11 +726,8 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -851,11 +737,8 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -865,11 +748,8 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -878,21 +758,15 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -902,11 +776,8 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -919,11 +790,8 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -932,11 +800,8 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -949,11 +814,8 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -961,15 +823,6 @@
         "node": ">=14"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.4",
-=======
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1270,7 +1123,6 @@
       "version": "4.52.5",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
       "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "cpu": [
         "x64"
       ],
@@ -1282,13 +1134,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-<<<<<<< HEAD
-      "version": "4.52.4",
-=======
       "version": "4.52.5",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
       "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "cpu": [
         "x64"
       ],
@@ -1301,11 +1149,8 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1318,11 +1163,8 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1331,11 +1173,8 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1345,11 +1184,8 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1358,21 +1194,15 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1392,11 +1222,8 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1408,11 +1235,8 @@
     },
     "node_modules/ansi-styles": {
       "version": "6.2.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1424,21 +1248,15 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1451,21 +1269,15 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
       "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -1502,22 +1314,15 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-<<<<<<< HEAD
-      "version": "2.8.16",
-=======
       "version": "2.8.21",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.21.tgz",
       "integrity": "sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1526,11 +1331,8 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1542,11 +1344,8 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1555,11 +1354,8 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1570,13 +1366,9 @@
       }
     },
     "node_modules/browserslist": {
-<<<<<<< HEAD
-      "version": "4.26.3",
-=======
       "version": "4.27.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
       "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -1594,19 +1386,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-<<<<<<< HEAD
-        "baseline-browser-mapping": "^2.8.9",
-        "caniuse-lite": "^1.0.30001746",
-        "electron-to-chromium": "^1.5.227",
-        "node-releases": "^2.0.21",
-        "update-browserslist-db": "^1.1.3"
-=======
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
         "electron-to-chromium": "^1.5.238",
         "node-releases": "^2.0.26",
         "update-browserslist-db": "^1.1.4"
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1617,11 +1401,8 @@
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1629,13 +1410,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-<<<<<<< HEAD
-      "version": "1.0.30001750",
-=======
       "version": "1.0.30001752",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001752.tgz",
       "integrity": "sha512-vKUk7beoukxE47P5gcVNKkDRzXdVofotshHwfR9vmpeFKxmI5PBpgOMC18LUJUA/DvJ70Y7RveasIBraqsyO/g==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -1655,11 +1432,8 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1683,11 +1457,8 @@
     },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1699,11 +1470,8 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1715,21 +1483,15 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "4.1.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1738,21 +1500,15 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1766,11 +1522,8 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1782,11 +1535,8 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1803,62 +1553,43 @@
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-<<<<<<< HEAD
-      "version": "1.5.237",
-=======
       "version": "1.5.244",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.244.tgz",
       "integrity": "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1896,11 +1627,8 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1909,11 +1637,8 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1929,11 +1654,8 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1945,11 +1667,8 @@
     },
     "node_modules/fastq": {
       "version": "1.19.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1958,11 +1677,8 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1974,11 +1690,8 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1994,11 +1707,8 @@
     },
     "node_modules/fraction.js": {
       "version": "4.3.7",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2009,10 +1719,6 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
-<<<<<<< HEAD
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-=======
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2032,7 +1738,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2041,11 +1746,8 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2054,11 +1756,8 @@
     },
     "node_modules/glob": {
       "version": "10.4.5",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2078,11 +1777,8 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2094,11 +1790,8 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2110,11 +1803,8 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2126,11 +1816,8 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2145,11 +1832,8 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2158,11 +1842,8 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2171,11 +1852,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2187,11 +1865,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2200,21 +1875,15 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -2229,11 +1898,8 @@
     },
     "node_modules/jiti": {
       "version": "1.21.7",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2242,20 +1908,14 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2267,11 +1927,8 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2283,11 +1940,8 @@
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2299,21 +1953,15 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -2324,11 +1972,8 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2337,11 +1982,8 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2350,11 +1992,8 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2367,11 +2006,8 @@
     },
     "node_modules/minimatch": {
       "version": "9.0.5",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2386,11 +2022,8 @@
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -2399,21 +2032,15 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2424,11 +2051,8 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -2445,23 +2069,16 @@
       }
     },
     "node_modules/node-releases": {
-<<<<<<< HEAD
-      "version": "2.0.23",
-=======
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2470,11 +2087,8 @@
     },
     "node_modules/normalize-range": {
       "version": "0.1.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2483,11 +2097,8 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2496,11 +2107,8 @@
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2509,21 +2117,15 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2532,21 +2134,15 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -2562,31 +2158,22 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2598,11 +2185,8 @@
     },
     "node_modules/pify": {
       "version": "2.3.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2611,11 +2195,8 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2624,11 +2205,8 @@
     },
     "node_modules/postcss": {
       "version": "8.5.6",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -2656,11 +2234,8 @@
     },
     "node_modules/postcss-import": {
       "version": "15.1.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2677,11 +2252,8 @@
     },
     "node_modules/postcss-js": {
       "version": "4.1.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -2706,11 +2278,8 @@
     },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -2752,11 +2321,8 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -2781,11 +2347,8 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2798,21 +2361,15 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -2832,11 +2389,8 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -2847,11 +2401,8 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -2863,21 +2414,14 @@
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-=======
     "node_modules/react-router": {
       "version": "6.30.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
@@ -2914,7 +2458,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2923,11 +2466,8 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2938,13 +2478,6 @@
       }
     },
     "node_modules/resolve": {
-<<<<<<< HEAD
-      "version": "1.22.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.0",
-=======
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
@@ -2952,7 +2485,6 @@
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -2968,11 +2500,8 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2981,13 +2510,9 @@
       }
     },
     "node_modules/rollup": {
-<<<<<<< HEAD
-      "version": "4.52.4",
-=======
       "version": "4.52.5",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
       "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3001,30 +2526,6 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-<<<<<<< HEAD
-        "@rollup/rollup-android-arm-eabi": "4.52.4",
-        "@rollup/rollup-android-arm64": "4.52.4",
-        "@rollup/rollup-darwin-arm64": "4.52.4",
-        "@rollup/rollup-darwin-x64": "4.52.4",
-        "@rollup/rollup-freebsd-arm64": "4.52.4",
-        "@rollup/rollup-freebsd-x64": "4.52.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
-        "@rollup/rollup-linux-arm64-musl": "4.52.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
-        "@rollup/rollup-linux-x64-gnu": "4.52.4",
-        "@rollup/rollup-linux-x64-musl": "4.52.4",
-        "@rollup/rollup-openharmony-arm64": "4.52.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
-        "@rollup/rollup-win32-x64-gnu": "4.52.4",
-        "@rollup/rollup-win32-x64-msvc": "4.52.4",
-=======
         "@rollup/rollup-android-arm-eabi": "4.52.5",
         "@rollup/rollup-android-arm64": "4.52.5",
         "@rollup/rollup-darwin-arm64": "4.52.5",
@@ -3047,17 +2548,13 @@
         "@rollup/rollup-win32-ia32-msvc": "4.52.5",
         "@rollup/rollup-win32-x64-gnu": "4.52.5",
         "@rollup/rollup-win32-x64-msvc": "4.52.5",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -3080,11 +2577,8 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -3092,11 +2586,8 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3105,11 +2596,8 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3121,11 +2609,8 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3134,11 +2619,8 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -3150,11 +2632,8 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3163,11 +2642,8 @@
     },
     "node_modules/string-width": {
       "version": "5.1.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3185,11 +2661,8 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3203,11 +2676,8 @@
     },
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3216,21 +2686,15 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3242,11 +2706,8 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.1.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3262,11 +2723,8 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3278,11 +2736,8 @@
     },
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3291,11 +2746,8 @@
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3317,11 +2769,8 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3333,11 +2782,8 @@
     },
     "node_modules/tailwindcss": {
       "version": "3.4.18",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3374,11 +2820,8 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3387,11 +2830,8 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3403,11 +2843,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3419,22 +2856,15 @@
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/update-browserslist-db": {
-<<<<<<< HEAD
-      "version": "1.1.3",
-=======
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
       "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "funding": [
         {
@@ -3464,22 +2894,15 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
-<<<<<<< HEAD
-      "version": "5.4.20",
-=======
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3538,11 +2961,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3557,11 +2977,8 @@
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3579,11 +2996,8 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3600,11 +3014,8 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3613,11 +3024,8 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3632,21 +3040,15 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3660,11 +3062,8 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3676,11 +3075,8 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-<<<<<<< HEAD
-=======
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
->>>>>>> 08cae8d727d54a10ccf387dded79479d6febc01a
       "dev": true,
       "license": "ISC"
     }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { BrowserRouter as Router, Routes, Route, NavLink } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
 import {
   Badge,
   Card,
@@ -17,10 +17,10 @@ import {
   getCategories,
   getImportSummary,
 } from './api'
-import GlobalReportView from './views/GlobalReportView'
-import RulesView from './views/RulesView'
-import AccountsView from './views/AccountsView'
-import PersonsView from './views/PersonsView'
+import GlobalReportView from './views/GlobalReportView.jsx'
+import RulesView from './views/RulesView.jsx'
+import AccountsView from './views/AccountsView.jsx'
+import PersonsView from './views/PersonsView.jsx'
 
 const categoryKindLabels = {
   income: 'Revenus',
@@ -509,7 +509,7 @@ function ImportsDashboard() {
 
 export default function App() {
   return (
-    <Router>
+    <BrowserRouter>
       <div className="min-h-screen bg-gray-50 text-gray-900">
         <div className="max-w-5xl mx-auto p-6 space-y-6">
           <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
@@ -519,7 +519,7 @@ export default function App() {
             </div>
             <nav className="flex gap-2">
               <NavLink
-                to="/"
+                to="/imports"
                 end
                 className={({ isActive }) =>
                   `px-3 py-2 rounded-md text-sm font-medium ${
@@ -584,6 +584,7 @@ export default function App() {
 
           <Routes>
             <Route path="/" element={<ImportsDashboard />} />
+            <Route path="/imports" element={<ImportsDashboard />} />
             <Route path="/imports/summary" element={<GlobalReportView />} />
             <Route path="/rules" element={<RulesView />} />
             <Route path="/accounts" element={<AccountsView />} />
@@ -591,6 +592,6 @@ export default function App() {
           </Routes>
         </div>
       </div>
-    </Router>
+    </BrowserRouter>
   )
 }


### PR DESCRIPTION
## Summary
- ensure the router uses BrowserRouter directly and restore the /imports route
- update navigation to point at /imports and keep view imports explicit
- regenerate the frontend lockfile via npm install

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6904e8e7320c83248cd83913c8e49eee