### PR TITLE
Add import check report endpoint and UI

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -101,6 +101,11 @@ export async function getImportReport(id) {
   return jsonOrThrow(res, `GET /imports/${id} failed`);
 }
 
+export async function getImportCheckReport(id) {
+  const res = await fetch(`${API_URL}/imports/${encodeURIComponent(id)}/check`);
+  return jsonOrThrow(res, `GET /imports/${id}/check failed`);
+}
+
 export async function getImportSummary() {
   const res = await fetch(`${API_URL}/imports/summary`);
   const data = await jsonOrThrow(res, 'GET /imports/summary failed');


### PR DESCRIPTION
## Summary
- add a GET /imports/:id/check endpoint that returns categorized transaction details for an import
- retain parsed metadata in stub mode so the check report works without a database connection
- expose the control report in the frontend with a dedicated button, table view, and API helper

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_6904f1581ec08324a31fbf4887bac664