### PR TITLE
Fix Excel parsing bounds and persist import state

### DIFF
--- a/backend/src/routes/imports.js
+++ b/backend/src/routes/imports.js
@@ -255,8 +255,10 @@ function parseWorksheet(worksheet, headerRowNumber = HEADER_ROW, firstDataRowNum
 
   const rows = [];
   const startRowNumber = firstDataRowNumber && firstDataRowNumber > headerRowNumber ? firstDataRowNumber : headerRowNumber + 1;
+  const worksheetRowCount = Number.isInteger(worksheet?.rowCount) && worksheet.rowCount > 0 ? worksheet.rowCount : worksheet.actualRowCount;
 
-  for (let rowNumber = startRowNumber; rowNumber <= worksheet.actualRowCount; rowNumber += 1) {
+  for (let rowNumber = startRowNumber; rowNumber <= worksheetRowCount; rowNumber += 1) {
+    if (rowNumber < 1 || (worksheet?.rowCount && rowNumber > worksheet.rowCount)) continue;
     const row = worksheet.getRow(rowNumber);
     if (!row || row.cellCount === 0) continue;
 
@@ -322,6 +324,10 @@ async function parseExcelFile(buffer, options = {}) {
   }
 
   const { headerRowNumber, firstDataRowNumber } = resolveWorksheetRows(options.startRow);
+
+  const startRow = firstDataRowNumber ?? headerRowNumber + 1;
+  const lastRow = worksheet?.rowCount ?? worksheet?.actualRowCount ?? 0;
+  console.debug(`[parseExcelFile] lignes traitées: ${startRow} → ${lastRow}`);
 
   const metadata = extractMetadata(worksheet, headerRowNumber);
   const rows = parseWorksheet(worksheet, headerRowNumber, firstDataRowNumber);


### PR DESCRIPTION
## Summary
- iterate over the worksheet row count to include the configured first row and trailing rows during Excel parsing and add diagnostics
- persist the latest import parameters, report, and cached file name in localStorage with a reset control on the imports dashboard

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6905b2805334832497c63668d5283d79