### PR TITLE
Add duplicate import warning message

### DIFF
--- a/backend/src/routes/imports.js
+++ b/backend/src/routes/imports.js
@@ -721,6 +721,15 @@ router.post('/excel', uploadSingle, async (req, res, next) => {
           duplicates: summary.duplicates,
         };
 
+        if (summary.ignored.duplicates > 0) {
+          const count = summary.ignored.duplicates;
+          const message =
+            count === 1
+              ? '1 transaction a été ignorée car elle existe déjà dans la base.'
+              : `${count} transactions ont été ignorées car elles existent déjà dans la base.`;
+          report.message = message;
+        }
+
         await client.query(
           `UPDATE import_batch
            SET status = $2, rows_count = $3, message = $4
@@ -741,6 +750,7 @@ router.post('/excel', uploadSingle, async (req, res, next) => {
     return res.status(201).json({
       import_batch_id: result.importBatch.id,
       report: result.report,
+      message: result.report.message ?? null,
     });
   } catch (error) {
     if (error?.code === '23505') {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -358,6 +358,9 @@ function ImportsDashboard() {
         })
       }
       setPostResp(data)
+      if (data?.message) {
+        alert(data.message)
+      }
       if (data?.import_batch_id) {
         setBatchId(String(data.import_batch_id))
       }


### PR DESCRIPTION
## Summary
- add a user-friendly duplicate warning to Excel import reports
- surface the warning in the API response and alert the user after an import

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6905bbed3d5c8324929c85401a6237dc